### PR TITLE
Introduce update_pages for Confluence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alita_tools"
-version = "0.0.56"
+version = "0.0.57"
 authors = [
   { name="Artem Rozumenko", email="support@projectalita.ai" },
   { name="Artem Dubrovskii", email="artem_dubrovskii@epam.com"}


### PR DESCRIPTION
create_page:
- add verification if page with the same title already exists (instead of try-except)

delete_page:
- simplified and make safe resolved_page_id

update_page:
- add page_title to perform update by title
- made body optional
- add verification for page renaming (if title already exists)
- delete try-except

update_pages:
- by list of page_ids
- by parent_id (performs bulk update to all childs)
