### PR TITLE
Fix the vectorstore state dictionary. Bump version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alita_tools"
-version = "0.0.59"
+version = "0.0.60"
 authors = [
   { name="Artem Rozumenko", email="support@projectalita.ai" },
   { name="Artem Dubrovskii", email="artem_dubrovskii@epam.com"}


### PR DESCRIPTION
Try to fix advanced jira mining:
1. Move the logic of creation of vectorstore to validator
2. Add new variable to search_data since now it should know the jira ticket id to correctly locate the vectore store persistent directory for particular jira id.
3. Add separately to the vectorestore the property _persistent_path since initially the vectorestore created without persistent path in the validator.
4. Fix the description and field information for search_data and search_data argument model.
Bump version.