### PR TITLE
Fix the issue for every search functionality for the Confluence space with digit at the beginning.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alita_tools"
-version = "0.0.87"
+version = "0.0.88"
 authors = [
   { name="Artem Rozumenko", email="support@projectalita.ai" },
   { name="Artem Dubrovskii", email="artem_dubrovskii@epam.com"}

--- a/src/alita_tools/confluence/api_wrapper.py
+++ b/src/alita_tools/confluence/api_wrapper.py
@@ -407,7 +407,7 @@ class ConfluenceAPIWrapper(BaseModel):
         if not self.space:
             cql = f'(type=page) and (title~"{query}" or text~"{query}")'
         else:
-            cql = f'(type=page and space={self.space}) and (title~"{query}" or text~"{query}")'
+            cql = f'(type=page and space="{self.space}") and (title~"{query}" or text~"{query}")'
         return self._process_search(cql)
 
     def search_by_title(self, query: str):
@@ -415,7 +415,7 @@ class ConfluenceAPIWrapper(BaseModel):
         if not self.space:
             cql = f'(type=page) and (title~"{query}")'
         else:
-            cql = f'(type=page and space={self.space}) and (title~"{query}")'
+            cql = f'(type=page and space="{self.space}") and (title~"{query}")'
         return self._process_search(cql)
 
     def site_search(self, query: str):
@@ -424,7 +424,7 @@ class ConfluenceAPIWrapper(BaseModel):
         if not self.space:
             cql = f'(type=page) and (siteSearch~"{query}")'
         else:
-            cql = f'(type=page and space={self.space}) and (siteSearch~"{query}")'
+            cql = f'(type=page and space="{self.space}") and (siteSearch~"{query}")'
         pages = self.client.cql(cql, start=0, limit=10).get("results", [])
         if not pages:
             return f"Unable to find anything using query {query}"


### PR DESCRIPTION
Fix the issue for the confluence spaces started from the digit. The search for such spaces using cql won't work. Solution is comming from the atlasian issue - https://jira.atlassian.com/browse/CONFSERVER-56542.
Also tested both on the mormal spaces started from letter and the spaces started from digit.
Also bump the version.