### PR TITLE
Return information about specified user in report Portal: api spec change

### DIFF
--- a/src/alita_tools/report_portal/report_portal_client.py
+++ b/src/alita_tools/report_portal/report_portal_client.py
@@ -61,7 +61,7 @@ class RPClient():
         return response.json()
 
     def get_user_information(self, username: str):
-        url = f"{self.endpoint}/api/v1/user/{username}"
+        url = f"{self.endpoint}/api/users/{username}"
         response = requests.request("GET", url, headers=self.headers)
         response.raise_for_status()
 


### PR DESCRIPTION
API deprecation: https://reportportal.io/docs/api/service-api/versions/5.11/get-user-using-get/
API new: https://reportportal.io/docs/api/service-api/get-user