### PR TITLE
731 (feat): add create issue via graphql

### DIFF
--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -120,8 +120,6 @@ closed
 """
 
 CREATE_ISSUE_ON_PROJECT_PROMPT = """
-**IMPORTANT**: Only OAuth App tokens are permitted (no Personal tokens). Ensure the "project:admin" scope is included as per GitHub documentation.
-
 This tool allows for creating GitHub issues within specified projects. Adhere to these steps:
 
 1. Specify both project and issue titles.
@@ -145,9 +143,7 @@ JSON:
 """
 
 UPDATE_ISSUE_ON_PROJECT_PROMPT = """
-**IMPORTANT**: Only OAuth App tokens are valid. Ensure "project:admin" is authorized.
-
-This tool updates GitHub issues. Follow these steps:
+This tool updates GitHub issues for the specified project. Follow these steps:
 
 - Provide the issue number and project title.
 - Optionally, adjust the issue's title, description, and other fields.

--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -942,7 +942,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
         project_title: str,
         desired_title: str,
         desired_body: str,
-        desired_fields: Dict[str, str],
+        desired_fields: Optional[Dict[str, str]] = None,
     ):
         _graphql_client = GraphQLClient(self._github_graphql_instance)
 
@@ -964,9 +964,10 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
             return f"Project has not been found. Error: {str(e)}. {str(result)}"
 
         try:
-            fields_to_update, missing_fields = _graphql_client.get_project_fields(
-                project, desired_fields, labels, assignableUsers
-            )
+            if not desired_fields:
+                fields_to_update, missing_fields = _graphql_client.get_project_fields(
+                    project, desired_fields, labels, assignableUsers
+                )
         except Exception as e:
             return f"Project fields are not returned. Error: {str(e)}"
 
@@ -988,12 +989,13 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
             return f"Convert Issue Not Created. Error: {str(e)}. {str(issue_number)}"
 
         try:
-            updated_fields = _graphql_client.update_issue_fields(
-                project_id=project_id,
-                desired_item_id=item_id,
-                desired_issue_item_id=issue_item_id,
-                fields=fields_to_update
-            )
+            if not desired_fields:
+                updated_fields = _graphql_client.update_issue_fields(
+                    project_id=project_id,
+                    desired_item_id=item_id,
+                    desired_issue_item_id=issue_item_id,
+                    fields=fields_to_update
+                )
         except Exception as e:
             return f"Issue fields are not updated. Error: {str(e)}. {str(updated_fields)}"
 
@@ -1012,7 +1014,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
         project_title: str,
         desired_title: str,
         desired_body: str,
-        desired_fields: Dict[str, str],
+        desired_fields: Optional[Dict[str, str]],
     ):
         _graphql_client = GraphQLClient(self._github_graphql_instance)
 

--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -120,64 +120,57 @@ closed
 """
 
 CREATE_ISSUE_ON_PROJECT_PROMPT = """
-**VERY IMPORTANT**: This method CANNOT be used with Personal token.
-It can work only with OAuth App token: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
-"X-Accepted-OAuth-Scopes" should include "project:admin"
+**IMPORTANT**: Only OAuth App tokens are permitted (no Personal tokens). Ensure the "project:admin" scope is included as per GitHub documentation.
 
-This tool allows you to create a new issue within a specified project in a GitHub repository. **VERY IMPORTANT**: Your input to this tool MUST strictly follow these rules:
+This tool allows for creating GitHub issues within specified projects. Adhere to these steps:
 
-- First, you must specify the title of the project.
-- Next, specify the title of the issue.
-- Optionally you can specify:
-  - a detailed description or body of the issue.
-  - additional fields based on project's requirements. For additional fields, write each field as a JSON key-value pair. 
+1. Specify both project and issue titles.
+2. Optionally, include a detailed issue description and any additional required fields in JSON format.
 
-Ensure you follow the JSON structure and utilize proper field names as expected within the project context.
+Ensure JSON fields are correctly named as expected by the project.
 
-For example, if you would like to create an issue within the "WebApp Redesign" project, titled "Fix Navigation Bar" with a body explaining the issue, and having additional configurations such as environment setting to "Staging" and prioritized as "Medium", you would pass in the following string:
+**Example**:
+For an issue titled "Fix Navigation Bar" in the "WebApp Redesign" project, addressing mobile view responsiveness, set as medium priority, in staging, and assigned to "dev_lead":
 
 Project: WebApp Redesign
 Issue Title: Fix Navigation Bar
-
-The navigation bar disappears on mobile view. Need a fix to ensure responsive compatibility across devices.
-
+Description: The navigation bar disappears on mobile view. Needs responsive fix.
+JSON:
 {
   "Environment": "Staging",
-  "SR Type": "Issue/Bug Report",
-  "SR Priority": "Medium",
+  "Priority": "Medium",
   "Labels": ["bug", "UI"],
   "Assignees": ["dev_lead"]
 }
 """
 
 UPDATE_ISSUE_ON_PROJECT_PROMPT = """
-**VERY IMPORTANT**: This method CANNOT be used with Personal token.
-It can work only with OAuth App token: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
-"X-Accepted-OAuth-Scopes" should include "project:admin"
+**IMPORTANT**: Only OAuth App tokens are valid. Ensure "project:admin" is authorized.
 
-This tool allows you to update an existing issue within a specified project in a GitHub repository. **VERY IMPORTANT**: Your input to this tool MUST strictly follow these rules:
+This tool updates GitHub issues. Follow these steps:
 
-- First, provide the unique number of the issue you wish to update.
-- Specify the title of the project containing the issue.
-- You can update the title of the issue if necessary.
-- Optionally, you can also update the description or body of the issue.
-- Additional fields in the issue can be adjusted or cleared based on the project's specifications. To do so, write each field as a JSON key-value pair. If you intend to clear any previously set fields, supply an empty string as the value for those fields.
+- Provide the issue number and project title.
+- Optionally, adjust the issue's title, description, and other fields.
+- Use JSON key-value pairs to update or clear fields, setting empty strings to clear.
 
-Ensure you follow the JSON structure and use the correct field names as expected within the project context.
+Ensure field names align with project requirements.
 
-For example, if you need to update an issue identified by number 42 within the "WebApp Redesign" project, changing its title to "Update Navigation Bar", revising the body to address new details, and modifying configurations such as setting the environment to "Production" while updating priority and clearing an unwanted label, you would structure your input as follows:
+**Example**:
+Update issue 42 in "WebApp Redesign," change its title, modify the description, and update settings:
 
 Issue Number: 42
 Project: WebApp Redesign
-Desired New Title: Update Navigation Bar
+New Title: Update Navigation Bar
 
-The navigation bar should now include dropdown menus based on user role. Ensure compatibility across all devices.
+Description:
+Implement dropdown menus based on user roles for full device compatibility.
 
+JSON:
 {
   "Environment": "Production",
-  "SR Type": "Enhancement",
-  "SR Priority": "High",
-  "Labels": ["UI"],  // Assuming a previous 'bug' label needs to be removed before
+  "Type": "Enhancement",
+  "Priority": "High",
+  "Labels": ["UI"],
   "Assignees": ["ui_team"]
 }
 """

--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -946,7 +946,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
     ):
         _graphql_client = GraphQLClient(self._github_graphql_instance)
 
-        full_name = self.github_repo_instance.full_name
+        full_name = self._github_repo_instance.full_name
         split_name = full_name.split("/")
         owner_name = split_name[0]
         repo_name = split_name[1]
@@ -956,6 +956,8 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
                 owner=owner_name, repo_name=repo_name, project_title=project_title
             )
             project = result.get("project")
+            labels = result.get("labels")
+            assignableUsers = result.get("assignableUsers")
             project_id = result.get("projectId")
             repository_id = result.get("repositoryId")
         except Exception as e:
@@ -963,7 +965,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
 
         try:
             fields_to_update, missing_fields = _graphql_client.get_project_fields(
-                project, desired_fields
+                project, desired_fields, labels, assignableUsers
             )
         except Exception as e:
             return f"Project fields are not returned. Error: {str(e)}"
@@ -978,7 +980,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
             return f"Draft Issue Not Created. Error: {str(e)}. {str(draft_issue_item_id)}"
 
         try:
-            issue_number = _graphql_client.convert_draft_issue(
+            issue_number, item_id, issue_item_id = _graphql_client.convert_draft_issue(
                 repository_id=repository_id,
                 draft_issue_id=draft_issue_item_id,
             )
@@ -988,8 +990,9 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
         try:
             updated_fields = _graphql_client.update_issue(
                 project_id=project_id,
-                desired_issue_item_id=draft_issue_item_id,
-                fields=fields_to_update,
+                desired_item_id=item_id,
+                desired_issue_item_id=issue_item_id,
+                fields=fields_to_update
             )
         except Exception as e:
             return f"Issue fields are not updated. Error: {str(e)}. {str(updated_fields)}"

--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -120,6 +120,10 @@ closed
 """
 
 CREATE_ISSUE_ON_PROJECT_PROMPT = """
+**VERY IMPORTANT**: This method CANNOT be used with Personal token.
+It can work only with OAuth App token: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+"X-Accepted-OAuth-Scopes" should include "project:admin"
+
 This tool allows you to create a new issue within a specified project in a GitHub repository. **VERY IMPORTANT**: Your input to this tool MUST strictly follow these rules:
 
 - First, you must specify the title of the project.
@@ -147,6 +151,10 @@ The navigation bar disappears on mobile view. Need a fix to ensure responsive co
 """
 
 UPDATE_ISSUE_ON_PROJECT_PROMPT = """
+**VERY IMPORTANT**: This method CANNOT be used with Personal token.
+It can work only with OAuth App token: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+"X-Accepted-OAuth-Scopes" should include "project:admin"
+
 This tool allows you to update an existing issue within a specified project in a GitHub repository. **VERY IMPORTANT**: Your input to this tool MUST strictly follow these rules:
 
 - First, provide the unique number of the issue you wish to update.
@@ -1068,6 +1076,9 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
         desired_fields: Optional[Dict[str, str]] = None,
     ) -> str:
         """
+        VERY IMPORTANT: This method CANNOT be used with Personal token but with OAuth token having project scope only
+        "X-Accepted-OAuth-Scopes" should include "project:admin"
+
         Creates an issue within a specified project using a series of GraphQL operations.
 
         The function initializes by identifying the repository, then extracts or creates the project and sets up
@@ -1157,6 +1168,9 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
         desired_fields: Optional[Dict[str, str]],
     ) -> str:
         """
+        VERY IMPORTANT: This method CANNOT be used with Personal token but with OAuth token having project scope only
+        "X-Accepted-OAuth-Scopes" should include "project:admin"
+        
         Updates an existing issue specified by issue number within a project, title, body, and other fields.
 
         Args:

--- a/src/alita_tools/github/graphql_github.py
+++ b/src/alita_tools/github/graphql_github.py
@@ -1,12 +1,35 @@
 from datetime import datetime, timezone
 from enum import Enum
 from string import Template
-from typing import Any, Optional, Dict
+from typing import Any, List, Tuple, Union, Optional, Dict
 
 from dateutil import parser
 
 
 class GraphQLTemplates(Enum):
+    """
+    Enum class to maintain consistent GraphQL query and mutation templates for GitHub operations.
+
+    Attributes:
+        QUERY_GET_PROJECT_INFO_TEMPLATE (Template): Template for a query to gather detailed info about projects and their contents
+        in a specific repository including labels, assignable users, and project items.
+        
+        MUTATION_CREATE_DRAFT_ISSUE (Template): Template for a mutation to create a draft issue in a specific project.
+        
+        MUTATION_CONVERT_DRAFT_INTO_ISSUE (Template): Template for a mutation to convert a draft issue to a regular issue in a repository.
+        
+        MUTATION_UPDATE_ISSUE (Template): Template for a mutation to update the title and body of a specific issue.
+        
+        MUTATION_UPDATE_ISSUE_FIELDS (Template): Template for a mutation to update the field values of a project item.
+        
+        MUTATION_SET_ISSUE_LABELS (Template): Template for a mutation to set labels to an issue.
+        
+        MUTATION_SET_ISSUE_ASSIGNEES (Template): Template for a mutation to add assignees to an issue.
+        
+        MUTATION_REMOVE_ISSUE_LABELS (Template): Template for a mutation to remove labels from an issue.
+        
+        MUTATION_REMOVE_ISSUE_ASSIGNEES (Template): Template for a mutation to remove assignees from an issue.
+    """
     QUERY_GET_PROJECT_INFO_TEMPLATE = Template("""
     query {
         repository(owner: "$owner", name: "$repo_name") {
@@ -219,7 +242,7 @@ class GraphQLClient:
         """
         payload = {"query": query}
         if variables:
-            payload["variables"] = variables
+            payload['variables'] = variables
 
         try:
             headers, response_data = self.requester.requestJsonAndCheck(
@@ -237,12 +260,27 @@ class GraphQLClient:
             return {'error': True, 'details': str(e)}
 
 
-    def get_project(self, owner: str, repo_name: str, project_title: str):
-        query = GraphQLTemplates.QUERY_GET_PROJECT_INFO_TEMPLATE.value.safe_substitute(
-            owner=owner, repo_name=repo_name
-        )
-        result = self._run_graphql_query(query)
+    def get_project(self, owner: str, repo_name: str, project_title: str) -> Union[Dict[str, Any], str]:
+        """
+        Fetches project details from a specific GitHub repository using GraphQL.
 
+        This method retrieves information including the project details, labels, and assignable users from a GitHub repository
+        by executing a GraphQL query. The query is constructed using a pre-defined template and customized with the given
+        repository owner and name parameters.
+
+        Args:
+            owner (str): The owner of the repository.
+            repo_name (str): The repository name.
+            project_title (str): The title of the project to find within the repository.
+
+        Returns:
+            Union[Dict[str, Any], str]: If the project is found, returns a dictionary containing keys "project", "projectId",
+            "repositoryId", "labels", and "assignableUsers". If an error occurs or the project is not found, returns an error message.
+        """
+        query_template = GraphQLTemplates.QUERY_GET_PROJECT_INFO_TEMPLATE.value
+        query = query_template.safe_substitute(owner=owner, repo_name=repo_name)
+        result = self._run_graphql_query(query)
+        
         if result['error']:
             return f"Error occurred: {result['details']}"
         
@@ -253,12 +291,12 @@ class GraphQLClient:
         projects = repository.get('projectsV2', {}).get('nodes', [])
         labels = repository.get('labels', {}).get('nodes', [])
         assignable_users = repository.get('assignableUsers', {}).get('nodes', [])
-        project = next((prj for prj in projects if prj['title'] == project_title), None)
         
+        project = next((prj for prj in projects if prj.get('title') == project_title), None)
         if not project:
             return f"Project '{project_title}' not found."
-
-        return { 
+        
+        return {
             "project": project,
             "projectId": project['id'],
             "repositoryId": repository['id'],
@@ -267,45 +305,78 @@ class GraphQLClient:
         }
 
 
-    def get_project_fields(self, project: str, desired_fields: Dict[str, str] = None, available_labels=None, available_assignees=None):
+    def get_project_fields(self, project: Dict[str, Any], desired_fields: Optional[Dict[str, List[str]]] = None, 
+                       available_labels: Optional[List[Dict[str, Any]]] = None, 
+                       available_assignees: Optional[List[Dict[str, Any]]] = None) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """
+        Processes project fields to update based on the provided desired field values.
+
+        This method maps the desired fields provided by the user to the actual fields available in the project.
+        It supports handling of single-select options, date fields, labels, and assignees. It checks for each field
+        stated in the desired fields if they exist in the project and updates them accordingly. If any field or 
+        option within a field does not exist, it is recorded in the missing fields list.
+
+        Args:
+            project (Dict[str, Any]): The dictionary containing project data with fields.
+            desired_fields (Optional[Dict[str, List[str]]]): A dictionary where keys represent field names and 
+                values are a list of option names to be updated. Default is None.
+            available_labels (Optional[List[Dict[str, Any]]]): List of dictionaries containing label data available in the project.  
+                Each label is a dictionary with at least 'name' and 'id'. Default is None.
+            available_assignees (Optional[List[Dict[str, Any]]]): List of dictionaries containing assignee data available in the project. 
+                Each assignee is a dictionary with at least 'name' and 'id'. Default is None.
+
+        Returns:
+            Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]: A tuple containing two lists:
+                - First list contains dictionaries of fields that can be updated.
+                - Second list contains dictionaries of missing fields with reasons.
+
+        Example:
+            fields_to_update, missing_fields = self.get_project_fields(
+                project=my_project,
+                desired_fields={"Due Date": ['2022-10-30'], "Assignee": ['username1', 'username2']},
+                available_labels=[{"name": "bug", "id": "label123"}],
+                available_assignees=[{"name": "dev1", "id": "user123"}]
+            )
+        """
         fields_to_update = []
         missing_fields = []
 
-        available_fields = {
-            field.get("name"): field for field in project["fields"]["nodes"] if field
-        }
-        label_map = {label['name']: label['id'] for label in available_labels}
-        assignee_map = {assignee['name']: assignee['id'] for assignee in available_assignees}
+        available_fields = {field.get("name"): field for field in project.get("fields", {}).get("nodes", []) if field}
+
+        label_map = {label['name']: label['id'] for label in (available_labels or [])}
+        assignee_map = {assignee['name']: assignee['id'] for assignee in (available_assignees or [])}
 
         def handle_single_select(field, option_name):
             options = field.get("options", [])
-            matched_option = next(
-                (option for option in options if option["name"] == option_name),
-                None,
-            )
-
+            matched_option = next((option for option in options if option['name'] == option_name), None)
             if matched_option:
                 fields_to_update.append({
                     "field_title": field['name'],
                     "field_type": field['dataType'],
                     "field_id": field['id'],
-                    "option_id": matched_option["id"],
+                    "option_id": matched_option['id'],
                 })
             else:
-                available_options = [option["name"] for option in options]
+                available_options = [option['name'] for option in options]
                 missing_fields.append({
                     "field": field['name'],
-                    "reason": f"Option '{option_name}' is not found. Available options: {str(available_options)}"
+                    "reason": f"Option '{option_name}' not found. Available options: {available_options}"
                 })
 
         def handle_date(field, option_name):
-            desired_date = self._convert_to_standard_utc(option_name)
-            fields_to_update.append({
-                "field_title": field['name'],
-                "field_type": field['dataType'],
-                "field_id": field['id'],
-                "field_value": desired_date,
-            })
+            try:
+                desired_date = self._convert_to_standard_utc(option_name)
+                fields_to_update.append({
+                    "field_title": field['name'],
+                    "field_type": field['dataType'],
+                    "field_id": field['id'],
+                    "field_value": desired_date,
+                })
+            except Exception as e:
+                missing_fields.append({
+                    "field": field['name'],
+                    "reason": f"Invalid date format: {str(e)}"
+                })
 
         def handle_labels_or_assignees(field, option_names, type_map, field_type):
             if option_names == []:
@@ -315,8 +386,8 @@ class GraphQLClient:
                     "field_value": []
                 })
             else:
-                mapped_ids = [type_map[name] for name in option_names if name in type_map]
-                if not mapped_ids:
+                valid_values = [name for name in option_names if name in type_map]
+                if not valid_values:
                     missing_fields.append({
                         "field": field['name'],
                         "reason": f"No valid {field_type.lower()} entries found for the provided values."
@@ -325,29 +396,53 @@ class GraphQLClient:
                     fields_to_update.append({
                         "field_title": field['name'],
                         "field_type": field['dataType'],
-                        "field_value": mapped_ids
+                        "field_value": [type_map[name] for name in valid_values]
                     })
 
-        for field_name, option_name in desired_fields.items():
-            if field_name in available_fields:
-                field = available_fields[field_name]
+        for field_name, option_names in (desired_fields or {}).items():
+            field = available_fields.get(field_name)
+            if field:
                 field_type = field.get("dataType")
-
-                if field_type == "SINGLE_SELECT":
-                    handle_single_select(field, option_name)
-                elif field_type == "DATE":
-                    handle_date(field, option_name)
-                elif field_type == "LABELS":
-                    handle_labels_or_assignees(field, option_name, label_map, field_type)
-                elif field_type == "ASSIGNEES":
-                    handle_labels_or_assignees(field, option_name, assignee_map, field_type)
+                handlers = {
+                    "SINGLE_SELECT": handle_single_select,
+                    "DATE": handle_date,
+                    "LABELS": lambda field, names: handle_labels_or_assignees(field, names, label_map, "LABELS"),
+                    "ASSIGNEES": lambda field, names: handle_labels_or_assignees(field, names, assignee_map, "ASSIGNEES")
+                }
+                handler = handlers.get(field_type)
+                if handler:
+                    handler(field, option_names)
+                else:
+                    missing_fields.append({"field": field_name, "reason": "Field type not supported"})
             else:
                 missing_fields.append({"field": field_name, "reason": "Field not found"})
 
         return fields_to_update, missing_fields
 
 
-    def create_draft_issue(self, project_id: str, title: str, body: str):
+    def create_draft_issue(self, project_id: str, title: str, body: str) -> Union[str, Dict[str, str]]:
+        """
+        Creates a draft issue in a specific GitHub project using the GraphQL API.
+
+        This method sends a mutation request to GitHub's GraphQL API to create a draft issue. 
+        It includes the project ID, title, and body of the issue as arguments and expects the draft issue ID on success.
+
+        Args:
+            project_id (str): The unique identifier for the project within GitHub.
+            title (str): The title for the draft issue.
+            body (str): The body or detailed description of the draft issue.
+
+        Returns:
+            Union[str, Dict[str, str]]: If successful, returns the created draft issue ID. 
+            If an error occurs during the process, returns a descriptive error message.
+
+        Example:
+            draft_issue_id = self.create_draft_issue(
+                project_id="project123", 
+                title="New Feature Proposal", 
+                body="Detailed description of the new feature."
+            )
+        """
         result = self._run_graphql_query(
             query=GraphQLTemplates.MUTATION_CREATE_DRAFT_ISSUE.value.template,
             variables={"projectId": project_id, "title": title, "body": body},
@@ -356,25 +451,43 @@ class GraphQLClient:
         if result['error']:
             return f"Error occurred: {result['details']}"
         
-        try:
-            draft_issue_data = result.get('data', {}).get('addProjectV2DraftIssue')
-            if not draft_issue_data:
-                return "Failed to create draft issue: No addProjectV2DraftIssue returned."
-
-            project_item = draft_issue_data.get('projectItem')
-            if not project_item:
-                return "Failed to create draft issue: No project item found."
-
-            draft_issue_id = project_item.get('id')
-            if not draft_issue_id:
-                return "Failed to create draft issue: ID not found."
-        except Exception as e:
-            return f"Create Draft Issue mutation failed. Error: {str(e)}"
-
+        draft_issue_data = result.get('data', {}).get('addProjectV2DraftIssue')
+        if not draft_issue_data:
+            return "Failed to create draft issue: No addProjectV2DraftIssue returned."
+        
+        project_item = draft_issue_data.get('projectItem')
+        if not project_item:
+            return "Failed to create draft issue: No project item found."
+        
+        draft_issue_id = project_item.get('id')
+        if not draft_issue_id:
+            return "Failed to create draft issue: ID not found."
+        
         return draft_issue_id
 
 
-    def convert_draft_issue(self, repository_id: str, draft_issue_id: str):
+    def convert_draft_issue(self, repository_id: str, draft_issue_id: str) -> Union[Tuple[int, str, str], str]:
+        """
+        Converts a draft issue to a standard GitHub issue using the GraphQL API.
+
+        This method sends a mutation request to GitHub's GraphQL API to convert a previously created draft issue
+        to a standard issue. It includes the repository ID and the draft issue ID as arguments.
+
+        Args:
+            repository_id (str): The unique identifier for the repository where the draft issue exists.
+            draft_issue_id (str): The unique identifier for the draft issue to be converted.
+
+        Returns:
+            Union[Tuple[int, str, str], str]: If successful, returns a tuple containing the issue number, 
+            the issue item ID, and the content ID of the converted issue. If an error occurs during the process,
+            returns a descriptive error message.
+        
+        Example:
+            issue_number, item_id, issue_item_id = self.convert_draft_issue(
+                repository_id="repo123",
+                draft_issue_id="draft123"
+            )
+        """
         result = self._run_graphql_query(
             query=GraphQLTemplates.MUTATION_CONVERT_DRAFT_INTO_ISSUE.value.template,
             variables={"draftItemId": draft_issue_id, "repositoryId": repository_id},
@@ -382,50 +495,68 @@ class GraphQLClient:
 
         if result['error']:
             return f"Error occurred: {result['details']}"
-        
-        try:
-            draft_issue_data = result.get('data', {}).get('convertProjectV2DraftIssueItemToIssue')
-            if not draft_issue_data:
-                return "Failed to convert draft issue: No convertProjectV2DraftIssueItemToIssue returned."
 
-            item = draft_issue_data.get('item')
-            item_id = item.get('id')
-            if not item:
-                return "Failed to convert draft issue: No issue item found."
-            
-            item_content = item.get('content')
-            if not item_content:
-                return "Failed to convert draft issue: No item content found."
+        draft_issue_data = result.get('data', {}).get('convertProjectV2DraftIssueItemToIssue')
+        if not draft_issue_data:
+            return "Failed to convert draft issue: No convertProjectV2DraftIssueItemToIssue returned."
 
-            issue_number = item_content.get('number')
-            issue_item_id = item_content.get('id')
-            if not issue_number:
-                return "Failed to convert draft issue: No issue number found."
-        except Exception as e:
-            return f"Convert Draft Issue mutation failed. Error: {str(e)}"
+        item = draft_issue_data.get('item')
+        if not item:
+            return "Failed to convert draft issue: No issue item found."
 
-        return issue_number, item_id, issue_item_id
+        item_content = item.get('content')
+        if not item_content:
+            return "Failed to convert draft issue: No item content found."
+
+        issue_number = item_content.get('number')
+        issue_item_id = item_content.get('id')
+        if not issue_number:
+            return "Failed to convert draft issue: No issue number found."
+
+        return issue_number, item.get('id'), issue_item_id
 
 
-    def update_issue(self, issue_id: str, desired_title: str, desired_body: str):
+    def update_issue(self, issue_id: str, desired_title: str, desired_body: str) -> Union[Dict[str, Any], str]:
+        """
+        Updates the title and body of an existing GitHub issue using the GraphQL API.
+
+        This function sends a mutation query to the GitHub GraphQL API to update the title and body
+        of a specific issue identified by its `issue_id`. Proper error handling and meaningful response 
+        messages are provided to assist with troubleshooting and validation.
+
+        Args:
+            issue_id (str): The unique identifier for the issue to be updated.
+            desired_title (str): The new title to be set for the issue.
+            desired_body (str): The new body content to be set for the issue.
+
+        Returns:
+            Union[Dict[str, Any], str]: If successful, returns the JSON response from the API containing the update details. 
+                                        If any error occurs, returns a descriptive error message as a string.
+
+        Example:
+            result = self.update_issue(
+                issue_id="issue123",
+                desired_title="Updated Title Example",
+                desired_body="Updated issue description here."
+            )
+        """
         query = GraphQLTemplates.MUTATION_UPDATE_ISSUE.value.template
-        query_variables = { "issueId": issue_id, "title": desired_title, "body": desired_body }
+        query_variables = {"issueId": issue_id, "title": desired_title, "body": desired_body}
 
         try:
             result = self._run_graphql_query(query, variables=query_variables)
-
             if result['error']:
                 return f"Error occurred: {result['details']}"
         except Exception as e:
             return f"Update Title and Body Issue mutation failed. Error: {str(e)}"
-        
+
         return result
 
     def update_issue_fields(
         self, project_id: str, 
         desired_item_id: str, desired_issue_item_id: str, 
         fields: Dict[str, str], 
-        item_label_ids: Optional[Any], item_assignee_ids: Optional[Any]
+        item_label_ids: Optional[Any] = [], item_assignee_ids: Optional[Any] = []
     ):
         updated_fields = []
         failed_fields = []
@@ -447,21 +578,28 @@ class GraphQLClient:
                 query_variables = None
             elif field_type == "LABELS":
                 label_ids = field.get("field_value")
-                if label_ids == []:
-                    query = GraphQLTemplates.MUTATION_REMOVE_ISSUE_LABELS.value.template
-                    query_variables = { "labelableId": desired_issue_item_id, "labelIds":  item_label_ids}
-                elif not label_ids:
-                    query = GraphQLTemplates.MUTATION_SET_ISSUE_LABELS.value.template
-                    query_variables = { "labelableId": desired_issue_item_id, "labelIds": label_ids}
+                query = (
+                    GraphQLTemplates.MUTATION_REMOVE_ISSUE_LABELS.value.template
+                    if label_ids == []
+                    else GraphQLTemplates.MUTATION_SET_ISSUE_LABELS.value.template
+                )
+                query_variables = (
+                    {"labelableId": desired_issue_item_id, "labelIds": item_label_ids}
+                    if label_ids == []
+                    else {"labelableId": desired_issue_item_id, "labelIds": label_ids}
+                )
             elif field_type == "ASSIGNEES":
                 assignee_ids = field.get("field_value")
-                
-                if assignee_ids == []:
-                    query = GraphQLTemplates.MUTATION_REMOVE_ISSUE_ASSIGNEES.value.template
-                    query_variables = {"assignableId": desired_issue_item_id, "assigneeIds": item_assignee_ids}
-                elif not assignee_ids:
-                    query = GraphQLTemplates.MUTATION_SET_ISSUE_ASSIGNEES.value.template
-                    query_variables = {"assignableId": desired_issue_item_id, "assigneeIds": assignee_ids}
+                query = (
+                    GraphQLTemplates.MUTATION_REMOVE_ISSUE_ASSIGNEES.value.template
+                    if assignee_ids == []
+                    else GraphQLTemplates.MUTATION_SET_ISSUE_ASSIGNEES.value.template
+                )
+                query_variables = (
+                    {"assignableId": desired_issue_item_id, "assigneeIds": item_assignee_ids}
+                    if assignee_ids == []
+                    else {"assignableId": desired_issue_item_id, "assigneeIds": assignee_ids}
+                )
             try:
                 result = self._run_graphql_query(query,variables=query_variables)
 
@@ -479,7 +617,23 @@ class GraphQLClient:
 
 
     @staticmethod
-    def _convert_to_standard_utc(date_input):
+    def _convert_to_standard_utc(date_input: str) -> str:
+        """
+        Converts a date string into an ISO 8601 formatted string with UTC timezone.
+
+        This method attempts to parse a date string into a datetime object, then formats it into
+        ISO 8601 format. If the input string cannot be successfully parsed, the method defaults to the 
+        current datetime.
+
+        Args:
+            date_input (str): The date string to be parsed and converted.
+
+        Returns:
+            str: An ISO 8601 formatted string representing the date in UTC timezone.
+
+        Example:
+            date_iso = MyClass._convert_to_standard_utc("2021-05-25T12:00:00")
+        """
         try:
             date_parsed = parser.parse(date_input)
         except ValueError:

--- a/src/alita_tools/github/graphql_github.py
+++ b/src/alita_tools/github/graphql_github.py
@@ -1,0 +1,336 @@
+from datetime import datetime, timezone
+from enum import Enum
+from string import Template
+from typing import Any, Dict
+
+from dateutil import parser
+
+
+class GraphQLTemplates(Enum):
+    QUERY_GET_PROJECT_INFO_TEMPLATE = Template("""
+    query {
+    repository(owner: "$owner", name: "$repo_name") {
+        id
+        projectsV2(first: 10) {
+        nodes
+        {
+            id
+            title
+            fields(first: 30) { 
+            nodes {
+                ... on ProjectV2SingleSelectField { 
+                id
+                dataType
+                name
+                options {
+                    id
+                    name
+                }
+                }
+                ... on ProjectV2FieldCommon { 
+                id
+                dataType
+                name
+                }
+            }
+            } 
+        }
+        }
+        issues(first: 10, orderBy: {
+                            field: CREATED_AT, 
+                            direction: DESC
+                            }) {
+        edges {
+            node {
+            id
+            number
+            title
+            }
+        }
+        }
+    }
+    }
+    """)
+
+    MUTATION_CREATE_DRAFT_ISSUE = Template("""
+    mutation ($projectId: ID!, $title: String!, $body: String!) {
+    addProjectV2DraftIssue(input: {
+        projectId: $projectId,
+        title: $title,
+        body: $body
+    }) {
+        projectItem {
+        id
+        }
+    }
+    }
+    """)
+
+    MUTATION_CONVERT_DRAFT_INTO_ISSUE = Template("""
+    mutation ($draftItemId: ID!, $repositoryId: ID!) {
+    convertProjectV2DraftIssueItemToIssue(input: {
+        itemId: $draftItemId,
+        repositoryId: $repositoryId
+    }) {
+        item {
+        content {
+            ... on Issue {
+            number
+            }
+        }
+        }
+    }
+    }
+    """)
+
+    MUTATION_UPDATE_ISSUE_FIELDS = Template("""
+    mutation {
+        updateProjectV2ItemFieldValue(input: 
+        {
+            projectId: "$project_id"
+            itemId: "$issue_item_id",
+            fieldId: "$field_id",
+            value: {
+                $value_content
+            }
+        }) {
+            projectV2Item {
+                id
+                fieldValues(first: 10) {
+                    nodes {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                            id
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """)
+
+
+class GraphQLClient:
+    def __init__(self, requester: Any):
+        self.requester = requester
+        pass
+
+    def _run_graphql_query(self, query: str, variables: Dict[str, str] = None):
+        """
+        Execute a GraphQL query using PyGithub's internal Requester, optionally including variables.
+        Args:
+            query: A string containing the GraphQL mutation or query
+            variables: A Python dictionary representing the variables in the query (default is None)
+        Returns:
+            A Python dictionary with the query results
+        """
+        payload = {"query": query}
+        if variables:
+            payload["variables"] = variables
+
+        try:
+            headers, response_data = self.requester.requestJsonAndCheck(
+                "POST",
+                self.requester.base_url + "/graphql",
+                input=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            errors = response_data.get('errors', [])
+            if errors:
+                return {'error': True, 'details': response_data['errors']}
+            else:
+                return {'error': False, 'data': response_data.get('data', {})}
+        except Exception as e:
+            return {'error': True, 'details': str(e)}
+
+
+    def get_project(self, owner: str, repo_name: str, project_title: str):
+        query = GraphQLTemplates.QUERY_GET_PROJECT_INFO_TEMPLATE.value.safe_substitute(
+            owner=owner, repo_name=repo_name
+        )
+        result = self._run_graphql_query(query)
+
+        if result['error']:
+            return f"Error occurred: {result['details']}"
+        
+        repository = result.get('data', {}).get('repository')
+        if not repository:
+            return "No repository data found."
+        
+        projects = repository.get('projectsV2', {}).get('nodes', [])
+        project = next((prj for prj in projects if prj['title'] == project_title), None)
+        
+        if not project:
+            return f"Project '{project_title}' not found."
+
+        return {"project": project, "projectId": project['id'], "repositoryId": repository['id']}
+
+
+    def get_project_fields(self, project: str, desired_fields: Dict[str, str] = None):
+        fields_to_update = []
+        missing_fields = []
+
+        available_fields = {
+            field.get("name"): field for field in project["fields"]["nodes"] if field
+        }
+
+        for field_name, option_name in desired_fields.items():
+            if field_name in available_fields:
+                field = available_fields[field_name]
+                field_id = field.get("id")
+                field_type = field.get("dataType")
+                if field_type == "SINGLE_SELECT":
+                    options = field.get("options", [])
+                    matched_option = next(
+                        (option for option in options if option["name"] == option_name),
+                        None,
+                    )
+
+                    if matched_option:
+                        fields_to_update.append(
+                            {
+                                "field_title": field_name,
+                                "field_type": field_type,
+                                "field_id": field_id,
+                                "option_id": matched_option["id"],
+                            }
+                        )
+                    else:
+                        available_options = [option["name"] for option in options]
+                        missing_fields.append(
+                            {
+                                "field": field_name,
+                                "reason": f"Option '{option_name}' is not found. "
+                                + f"Available options: {str(available_options)}",
+                            }
+                        )
+                elif field_type == "DATE":
+                    desired_date = self._convert_to_standard_utc(option_name)
+                    fields_to_update.append(
+                        {
+                            "field_title": field_name,
+                            "field_type": field_type,
+                            "field_id": field_id,
+                            "field_value": desired_date,
+                        }
+                    )
+                elif (field_type == "LABELS" or field_type == "ASSIGNEES"):
+                    fields_to_update.append(
+                        {
+                            "field_title": field_name,
+                            "field_type": field_type,
+                            "field_id": field_id,
+                            "field_value": option_name,
+                        }
+                    )
+            else:
+                missing_fields.append({"field": field_name, "reason": "Field is not found"})
+
+        return fields_to_update, missing_fields
+
+
+    def create_draft_issue(self, project_id: str, title: str, body: str):
+        result = self._run_graphql_query(
+            query=GraphQLTemplates.MUTATION_CREATE_DRAFT_ISSUE.value.template,
+            variables={"projectId": project_id, "title": title, "body": body},
+        )
+
+        if result['error']:
+            return f"Error occurred: {result['details']}"
+        
+        try:
+            draft_issue_data = result.get('data', {}).get('addProjectV2DraftIssue')
+            if not draft_issue_data:
+                return "Failed to create draft issue: No addProjectV2DraftIssue returned."
+
+            project_item = draft_issue_data.get('projectItem')
+            if not project_item:
+                return "Failed to create draft issue: No project item found."
+
+            draft_issue_id = project_item.get('id')
+            if not draft_issue_id:
+                return "Failed to create draft issue: ID not found."
+        except Exception as e:
+            return f"Create Draft Issue mutation failed. Error: {str(e)}"
+
+        return draft_issue_id
+
+
+    def convert_draft_issue(self, repository_id: str, draft_issue_id: str):
+        result = self._run_graphql_query(
+            query=GraphQLTemplates.MUTATION_CONVERT_DRAFT_INTO_ISSUE.value.template,
+            variables={"draftItemId": draft_issue_id, "repositoryId": repository_id},
+        )
+
+        if result['error']:
+            return f"Error occurred: {result['details']}"
+        
+        try:
+            draft_issue_data = result.get('data', {}).get('convertProjectV2DraftIssueItemToIssue')
+            if not draft_issue_data:
+                return "Failed to convert draft issue: No convertProjectV2DraftIssueItemToIssue returned."
+
+            item = draft_issue_data.get('item')
+            if not item:
+                return "Failed to convert draft issue: No issue item found."
+            
+            item_content = item.get('content')
+            if not item_content:
+                return "Failed to convert draft issue: No item content found."
+
+            issue_number = item_content.get('number')
+            if not issue_number:
+                return "Failed to convert draft issue: No issue number found."
+        except Exception as e:
+            return f"Convert Draft Issue mutation failed. Error: {str(e)}"
+
+        return issue_number
+
+
+    def update_issue(
+        self, project_id: str, desired_issue_item_id: str, fields: Dict[str, str]
+    ):
+        updated_fields = []
+        failed_fields = []
+        for field in fields:
+            field_type = field.get("field_type")
+            
+            if field_type == "DATE":
+                value_content = f'date: "{field.get("field_value")}"'
+            elif field_type == "SINGLE_SELECT":
+                value_content = f'singleSelectOptionId: "{field.get("option_id")}"'
+            elif (field_type == "LABELS" or field_type == "ASSIGNEES"):
+                value_content = f'text: "{field.get("field_value")}"'
+
+            query = GraphQLTemplates.MUTATION_UPDATE_ISSUE_FIELDS.value.safe_substitute(
+                project_id=project_id,
+                issue_item_id=desired_issue_item_id,
+                field_id=field.get("field_id"),
+                value_content=value_content,
+            )
+            try:
+                result = self._run_graphql_query(query)
+
+                if result['error']:
+                    failed_fields.append(field.get("field_title"))
+                    return f"Error occurred: {result['details']}"
+                
+                if result:
+                    updated_fields.append(field.get("field_title"))
+            except Exception:
+                failed_fields.append(field.get("field_title"))
+                continue
+
+        return updated_fields
+
+
+    @staticmethod
+    def _convert_to_standard_utc(date_input):
+        try:
+            date_parsed = parser.parse(date_input)
+        except ValueError:
+            date_parsed = datetime.now()
+
+        date_iso8601 = date_parsed.replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        return date_iso8601

--- a/src/docs/guides/github_oauth_app.md
+++ b/src/docs/guides/github_oauth_app.md
@@ -1,7 +1,7 @@
 ### Guide for GitHub OAuth App
 
 - Create a new OAuth App: 
-GitHub > Settings > Developer Settings > OAuth Apps
+GitHub > Settings > Developer Settings > OAuth Apps \
 https://github.com/settings/developers
 
 - Install `gh` on your local machine
@@ -20,4 +20,74 @@ gh auth login --scopes "project"
 MacOS:
 ```bash
 gh auth token
+```
+
+### Usage
+
+#### Create issue on project
+
+> src/alita_tools/github/api_wrapper.py::create_issue_on_project
+
+```python
+from src.alita_tools.github import AlitaGitHubAPIWrapper
+from pydantic import ValidationError
+
+try:
+    api = AlitaGitHubAPIWrapper(
+        github="https://github.com",
+        github_repository="<owner_name>/<repository_name>",
+        github_base_branch="master",
+        active_branch="master",
+        github_access_token="<oauth_app_token_with_project_scope>"
+    )
+except ValidationError as err:
+    print(err.json(indent=4))
+
+project_title = "<project_title>" # board title
+issue_title = "Test Issue Title"
+issue_description = "Test Description"
+desired_fields = {
+    "Environment": "Staging",
+    "SR Type": "Issue/Bug Report",
+    "SR Priority": "Medium",
+    "Labels": ["bug", "documentation"],
+    "Assignees": ["<assignee_name>"]
+}
+
+data = api.create_issue_on_project(project_title, issue_title, issue_description, desired_fields)
+print(f"\n> Result: {data}\n")
+```
+
+#### Update issue on project
+> src/alita_tools/github/api_wrapper.py::update_issue_on_project
+
+```python
+from src.alita_tools.github import AlitaGitHubAPIWrapper
+from pydantic import ValidationError
+
+try:
+    api = AlitaGitHubAPIWrapper(
+        github="https://github.com",
+        github_repository="<owner_name>/<repository_name>",
+        github_base_branch="master",
+        active_branch="master",
+        github_access_token="<oauth_app_token_with_project_scope>"
+    )
+except ValidationError as err:
+    print(err.json(indent=4))
+
+project_title = "<project_title>" # board title
+issue_number = "2"
+issue_title = "New Test Issue Title"
+issue_description = "New Test Description"
+desired_fields = {
+    "Environment": "All",
+    "SR Type": "", # field will be removed
+    "SR Priority": "High",
+    "Labels": ["enchancement"],
+    "Assignees": [] # all assignees will be removed
+}
+
+data = api.update_issue_on_project(issue_number, project_title, issue_title, issue_description, desired_fields)
+print(f"\n> Result: {data}\n")
 ```

--- a/src/docs/guides/github_oauth_app.md
+++ b/src/docs/guides/github_oauth_app.md
@@ -26,8 +26,12 @@ gh auth token
 
 #### Create issue on project
 
-> src/alita_tools/github/api_wrapper.py::create_issue_on_project
+> VERY IMPORTANT: This method CANNOT be used with Personal token but with OAuth token having project scope only
+> "X-Accepted-OAuth-Scopes" should include "project:admin"
 
+
+src/alita_tools/github/api_wrapper.py::create_issue_on_project
+\
 ```python
 from src.alita_tools.github import AlitaGitHubAPIWrapper
 from pydantic import ValidationError
@@ -59,8 +63,12 @@ print(f"\n> Result: {data}\n")
 ```
 
 #### Update issue on project
-> src/alita_tools/github/api_wrapper.py::update_issue_on_project
+> VERY IMPORTANT: This method CANNOT be used with Personal token but with OAuth token having project scope only
+> "X-Accepted-OAuth-Scopes" should include "project:admin"
 
+
+src/alita_tools/github/api_wrapper.py::update_issue_on_project
+\
 ```python
 from src.alita_tools.github import AlitaGitHubAPIWrapper
 from pydantic import ValidationError

--- a/src/docs/guides/github_oauth_app.md
+++ b/src/docs/guides/github_oauth_app.md
@@ -1,0 +1,23 @@
+### Guide for GitHub OAuth App
+
+- Create a new OAuth App: 
+GitHub > Settings > Developer Settings > OAuth Apps
+https://github.com/settings/developers
+
+- Install `gh` on your local machine
+MacOS:
+```bash
+brew install gh
+```
+
+- Log in GitHub using `project` scope:
+MacOS:
+```bash
+gh auth login --scopes "project"
+```
+
+- Get auth token:
+MacOS:
+```bash
+gh auth token
+```


### PR DESCRIPTION
Feature change for [#731](https://github.com/ProjectAlita/projectalita.github.io/issues/731)

### Changes
Added 2 new methods: `create_issue_on_project` and `update_issue_on_project`
These methods use GitHub GraphQL mutations. Since they work with projects, they cannot be used with Personal token (it grants only project:read scope). If user can obtain only Personal token, they should use other methods developed before: `create_issue` and `update_issue`.
Please review documentation as well: [github_oauth_app.md](https://github.com/ProjectAlita/application-tools/blob/661fd10d6c3f8d886260e58c0c5c58c32cd729f3/src/docs/guides/github_oauth_app.md)

### TODO

- [ ] **QA Team**: Test properly with different input configurations
- [ ] **QA Team**: Test properly with Agent / SDK, in case of different tokens and LLMs method recognition
- [x] Complete documentation
- [x] Add labels / assignees
- [x] Re-think update_issue method
- [x] Prepare guide how to get OAuth app token 

