### PR TITLE
Feat(828): Fix github repository handling, fix loader description

### DIFF
--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -4,6 +4,7 @@ from json import dumps, loads
 import fnmatch
 from typing import Dict, Any, Optional, List, Union
 import tiktoken
+from langchain_core.tools import ToolException
 from pydantic import model_validator, create_model, BaseModel, Field
 from pydantic.fields import PrivateAttr
 from langchain.utils import get_from_dict_or_env
@@ -461,6 +462,16 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
     github_app_id: Optional[str] = None
     github_app_private_key: Optional[str] = None
 
+    def clean_repository_name(repo_link):
+        import re
+
+        match = re.match(r"^(?:https?://github\.com/|git@github\.com:)?([^/]+/[^/.]+)(?:\.git)?$", repo_link)
+
+        if not match:
+            raise ToolException("Repository field should be in '<owner>/<repo>' format.")
+
+        return match.group(1)
+
     @model_validator(mode='before')
     @classmethod
     def validate_environment(cls, values: Dict) -> Dict:
@@ -487,6 +498,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
 
         github_repository = get_from_dict_or_env(
             values, "github_repository", "GITHUB_REPOSITORY")
+        github_repository = cls.clean_repository_name(github_repository)
 
         active_branch = get_from_dict_or_env(
             values, "active_branch", "ACTIVE_BRANCH", default='ai')
@@ -1058,25 +1070,25 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
                whitelist: Optional[List[str]] = None,
                blacklist: Optional[List[str]] = None) -> str:
         """
-        Generates file content from the specified branch while honoring whitelist and blacklist patterns.
+        Generates file content from a branch using whitelist and blacklist filters.
 
         Parameters:
-            branch (Optional[str]): The branch to set as active before listing files. If None, the current active branch is used.
-            whitelist (Optional[List[str]]): A list of file extensions or paths to include. If None, all files are included.
-            blacklist (Optional[List[str]]): A list of file extensions or paths to exclude. If None, no files are excluded.
+            branch (Optional[str]): Branch for file listing, defaults to current if None.
+            whitelist (Optional[List[str]]): Extensions or paths to include, defaults to all.
+            blacklist (Optional[List[str]]): Extensions or paths to exclude, defaults to none.
 
         Returns:
-            generator: A generator that yields the content of files that match the whitelist and do not match the blacklist.
+            generator: Yields content of files matching whitelist but not blacklist.
 
         Example:
-            # Set the active branch to 'feature-branch' and include only '.py' files, excluding 'test_' files
+            # Use 'feature-branch', include only '.py', exclude 'test_' prefixed files
             file_generator = loader(branch='feature-branch', whitelist=['*.py'], blacklist=['*test_*'])
-            for file_content in file_generator:
-                print(file_content)
+            for content in file_generator:
+                print(content)
 
         Notes:
-            - The whitelist and blacklist patterns use Unix shell-style wildcards.
-            - If both whitelist and blacklist are provided, a file must match the whitelist and not match the blacklist to be included.
+            - Utilizes Unix shell-style wildcards.
+            - Inclusion requires passing both whitelist and blacklist criteria.
         """
         from ..chunkers.code.codeparser import parse_code_files_for_db
         _files = self._get_files("", branch or self.active_branch)

--- a/src/alita_tools/github/api_wrapper.py
+++ b/src/alita_tools/github/api_wrapper.py
@@ -465,7 +465,7 @@ class AlitaGitHubAPIWrapper(GitHubAPIWrapper):
     def clean_repository_name(repo_link):
         import re
 
-        match = re.match(r"^(?:https?://github\.com/|git@github\.com:)?([^/]+/[^/.]+)(?:\.git)?$", repo_link)
+        match = re.match(r"^(?:https?://[^/]+/|git@[^:]+:)?([^/]+/[^/.]+)(?:\.git)?$", repo_link)
 
         if not match:
             raise ToolException("Repository field should be in '<owner>/<repo>' format.")


### PR DESCRIPTION
### Changes
- New feature [#828](https://github.com/ProjectAlita/projectalita.github.io/issues/828):
We have a suggestion/request based on common support issues related to GitHub repository configuration in Elitea. If user sets repository as 'owner/repo.git' - '.git' suffix will be ignored

### Local testing
<img width="900" alt="gh_828_valid_case" src="https://github.com/user-attachments/assets/7aa406c8-c036-4e90-ad60-5e2a7d7d5c87" />
<img width="900" alt="gh_828_invalid_case" src="https://github.com/user-attachments/assets/3bd06743-973f-441a-925c-33effdc3b50d" />
