### PR TITLE
Fix(833): Change gitlab tool for repo_instance usage

### DIFF
--- a/src/alita_tools/gitlab/tools.py
+++ b/src/alita_tools/gitlab/tools.py
@@ -169,7 +169,7 @@ class GetPullRequesChanges(BaseTool):
 
     def _run(self, pr_number: str):
         try:
-            repo = self.api_wrapper.repo_instance
+            repo = self.api_wrapper._repo_instance
             try:
                 mr = repo.mergerequests.get(pr_number)
             except GitlabGetError as e:
@@ -209,7 +209,7 @@ class CreatePullRequestChangeComment(BaseTool):
     def _run(self, pr_number: str, file_path: str, line_number: int, comment: str, *args):
         if line_number == 0:
             raise ToolException("Line number for comment must be greater than 0")
-        repo = self.api_wrapper.repo_instance
+        repo = self.api_wrapper._repo_instance
         try:
             mr = repo.mergerequests.get(pr_number)
         except GitlabGetError as e:


### PR DESCRIPTION
### Change
Bugfix for [#833](https://github.com/ProjectAlita/projectalita.github.io/issues/833)

### Root cause
Invalid link to repo_instance in tool file. It should be _repo_instance instead.
Missed during PR review

### Local testing
<img width="900" alt="gl_833_success" src="https://github.com/user-attachments/assets/5c9e9e94-03f6-494e-bbb8-d5abfbf77b03" />
