### PR TITLE
Fix ADO Repos list_pull_request_diffs

### DIFF
--- a/src/alita_tools/ado/repos/repos_wrapper.py
+++ b/src/alita_tools/ado/repos/repos_wrapper.py
@@ -537,13 +537,13 @@ class ReposApiWrapper(BaseCodeToolApiWrapper):
                 if isinstance(base_content, ToolException):
                     msg = f"Failed to process base file content for path: {path}: {str(base_content)}"
                     logger.error(msg)
-                    return str(ToolException(msg))
+                    return msg
 
                 target_content = self.get_file_content(source_commit_id, path)
                 if isinstance(target_content, ToolException):
                     msg = f"Failed to process target file content for path: {path}: {str(target_content)}"
                     logger.error(msg)
-                    return str(ToolException(msg))
+                    return msg
 
                 diff = generate_diff(base_content, target_content, path)
             else:

--- a/src/alita_tools/ado/repos/repos_wrapper.py
+++ b/src/alita_tools/ado/repos/repos_wrapper.py
@@ -534,18 +534,18 @@ class ReposApiWrapper(BaseCodeToolApiWrapper):
             # but the model is not accessible in azure.devops.v7_0.git.models
             if change_type == "edit":
                 base_content = self.get_file_content(target_commit_id, path)
-                target_content = self.get_file_content(source_commit_id, path)
-
                 if isinstance(base_content, ToolException):
-                    msg = f"Failed to process file content for path: {path}: {str(base_content)}"
+                    msg = f"Failed to process base file content for path: {path}: {str(base_content)}"
                     logger.error(msg)
                     return str(ToolException(msg))
-                elif isinstance(target_content, ToolException):
-                    msg = f"Failed to process file content for path: {path}: {str(target_content)}"
+
+                target_content = self.get_file_content(source_commit_id, path)
+                if isinstance(target_content, ToolException):
+                    msg = f"Failed to process target file content for path: {path}: {str(target_content)}"
                     logger.error(msg)
                     return str(ToolException(msg))
-                else:
-                    diff = generate_diff(base_content, target_content, path)
+
+                diff = generate_diff(base_content, target_content, path)
             else:
                 diff = f"Change Type: {change_type}"
 

--- a/src/alita_tools/ado/utils.py
+++ b/src/alita_tools/ado/utils.py
@@ -27,3 +27,12 @@ def generate_diff(base_text, target_text, file_path):
     )
 
     return "".join(diff)
+
+def get_content_from_generator(content_generator):
+    def safe_decode(chunk):
+        try:
+            return chunk.decode("utf-8")
+        except UnicodeDecodeError:
+            return chunk.decode("ascii", errors="backslashreplace")
+
+    return "".join(safe_decode(chunk) for chunk in content_generator)

--- a/src/tests/ado/repos/test_unit_ado_repos.py
+++ b/src/tests/ado/repos/test_unit_ado_repos.py
@@ -589,7 +589,7 @@ class TestReposToolsPositive:
             return_value=MagicMock(version=branch_name, version_type="branch"),
         ) as mock_version_descriptor:
             mock_git_client.get_item_text.return_value = [b"Hello", b" ", b"World!"]
-            result = repos_wrapper._read_file(file_path)
+            result = repos_wrapper._read_file(file_path, branch_name)
 
             expected_content = "Hello World!"
             assert result == expected_content
@@ -1169,7 +1169,7 @@ class TestReposToolsExceptions:
         error_message = "File does not exist"
         mock_git_client.get_item_text.side_effect = Exception(error_message)
 
-        result = repos_wrapper._read_file(file_path)
+        result = repos_wrapper._read_file(file_path, branch_name)
 
         assert isinstance(result, ToolException)
         assert (
@@ -1245,9 +1245,9 @@ class TestReposToolsExceptions:
         result = repos_wrapper.comment_on_pull_request(comment_query)
 
         assert isinstance(result, ToolException)
-        assert str(result) == "Unable to make comment due to error:\nAPI Error"
+        assert str(result) == "An error occurred:\nAPI Error"
         mock_logger.error.assert_called_once_with(
-            "Unable to make comment due to error:\nAPI Error"
+            "An error occurred:\nAPI Error"
         )
     
     @patch("alita_tools.ado.repos.repos_wrapper.logger")

--- a/src/tests/ado/test_ado_utils.py
+++ b/src/tests/ado/test_ado_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from alita_tools.ado.utils import generate_diff
+from alita_tools.ado.utils import generate_diff, extract_old_new_pairs, get_content_from_generator
 
 @pytest.mark.unit
 @pytest.mark.ado
@@ -106,3 +106,111 @@ class TestAdoUtils:
             generate_diff(base_text, target_text, file_path)
         
         assert "'NoneType' object has no attribute 'splitlines'" in str(exc.value)
+
+    # Tests for extract_old_new_pairs
+    @pytest.mark.positive
+    def test_extract_old_new_pairs_positive(self):
+        """Test successful extraction of old and new content pairs."""
+        file_query = """
+        Some introductory text.
+        OLD <<<<
+        This is the old content.\nLine 2 of old content.
+        >>>> OLD
+        Some text in between.
+        NEW <<<<
+        This is the new content.\nLine 2 of new content.
+        >>>> NEW
+        Some trailing text.
+        """
+        expected = [("This is the old content.\nLine 2 of old content.", "This is the new content.\nLine 2 of new content.")]
+        result = extract_old_new_pairs(file_query)
+        assert result == expected
+
+    @pytest.mark.positive
+    def test_extract_old_new_pairs_multiple(self):
+        """Test extraction with multiple old/new pairs."""
+        file_query = """
+        OLD <<<< old1 >>>> OLD
+        NEW <<<< new1 >>>> NEW
+        OLD <<<< old2 >>>> OLD
+        NEW <<<< new2 >>>> NEW
+        """
+        expected = [("old1", "new1"), ("old2", "new2")]
+        result = extract_old_new_pairs(file_query)
+        assert result == expected
+
+    @pytest.mark.negative
+    def test_extract_old_new_pairs_no_match(self):
+        """Test extraction when no old/new blocks are present."""
+        file_query = "Just some regular text without markers."
+        expected = []
+        result = extract_old_new_pairs(file_query)
+        assert result == expected
+
+    @pytest.mark.negative
+    def test_extract_old_new_pairs_empty_input(self):
+        """Test extraction with empty input string."""
+        file_query = ""
+        expected = []
+        result = extract_old_new_pairs(file_query)
+        assert result == expected
+
+    @pytest.mark.negative
+    def test_extract_old_new_pairs_mismatched_pairs(self):
+        """Test extraction with mismatched numbers of OLD and NEW blocks."""
+        file_query = """
+        OLD <<<< old1 >>>> OLD
+        NEW <<<< new1 >>>> NEW
+        OLD <<<< old2 >>>> OLD
+        """
+        # zip will stop at the shortest list, so only one pair is expected
+        expected = [("old1", "new1")]
+        result = extract_old_new_pairs(file_query)
+        assert result == expected
+
+    # Tests for get_content_from_generator
+    @pytest.mark.positive
+    def test_get_content_from_generator_utf8(self):
+        """Test decoding content from a generator with UTF-8 bytes."""
+        def content_generator():
+            yield b"Hello, "
+            yield b"W\xc3\xb6rld!" # "World!" with ö
+
+        expected = "Hello, Wörld!"
+        result = get_content_from_generator(content_generator())
+        assert result == expected
+
+    @pytest.mark.positive
+    def test_get_content_from_generator_mixed_encoding(self):
+        """Test decoding content with mixed valid and invalid UTF-8 bytes."""
+        def content_generator():
+            yield b"Valid UTF-8. "
+            yield b"Invalid byte: \xff"
+            yield b". More valid: \xc3\xa4" # ä
+
+        # The invalid byte \xff should be replaced by a backslash escape sequence
+        expected = "Valid UTF-8. Invalid byte: \\xff. More valid: ä"
+        result = get_content_from_generator(content_generator())
+        assert result == expected
+
+    @pytest.mark.negative
+    def test_get_content_from_generator_invalid_utf8_fallback(self):
+        """Test fallback decoding when UTF-8 fails."""
+        def content_generator():
+            yield b"Invalid sequence: \x80\x99" # Invalid UTF-8 start bytes
+
+        # Expect backslash replacement for invalid bytes
+        expected = "Invalid sequence: \\x80\\x99"
+        result = get_content_from_generator(content_generator())
+        assert result == expected
+
+    @pytest.mark.negative
+    def test_get_content_from_generator_empty(self):
+        """Test with an empty generator."""
+        def content_generator():
+            if False: # Never yields
+                 yield
+
+        expected = ""
+        result = get_content_from_generator(content_generator())
+        assert result == expected


### PR DESCRIPTION
### Changes
- Bug: #203 
- Fixed method `list_pull_request_diffs` to properly handling content in PRs
- Added & fixed unit tests for ADO repos

### Root Cause
- During decoding chunks in content there was issue in decoding to `utf-8`. The fix now works with fallback to `ascii`:
1. `\xff` -> `\\xff`
2. `\xc3\xa4` -> `ä`
3. `\x80\x99` -> `\\x80\\x99`

### Local testing
- Tested successfully on provided agent:
<img width="900" alt="local_203_fix" src="https://github.com/user-attachments/assets/fbc5a800-262c-4924-8860-ed365b76402a" />

- Unit test results: 
<img width="489" alt="unit_tests_ado_utils" src="https://github.com/user-attachments/assets/20bb6c5c-b5cc-437b-8c08-d6c88fefff62" />
<img width="344" alt="unit_tests_ado_repos" src="https://github.com/user-attachments/assets/9d6d05a1-b85d-4e24-8115-5efc6ba45ee1" />
