### PR TITLE
fix: clean up libs, add dependency for cv2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ FigmaPy==2018.1.0
 pytesseract~=0.3.13
 pypdf2~=3.0.1
 astor~=0.8.1
+opencv-python==4.11.0.86 # for cv2 library

--- a/src/alita_tools/ocr/api_wrapper.py
+++ b/src/alita_tools/ocr/api_wrapper.py
@@ -1,9 +1,7 @@
 import io
 import os
-import re
 import logging
 import fitz  # PyMuPDF
-import cv2
 from PIL import Image
 import numpy as np
 from typing import Optional, Any, Dict, List

--- a/src/alita_tools/ocr/text_detection.py
+++ b/src/alita_tools/ocr/text_detection.py
@@ -1,8 +1,7 @@
-import os
 import logging
 import numpy as np
 import cv2
-from typing import List, Tuple, Any, Optional, Dict
+from typing import Any, Dict
 import pytesseract
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Changes
- Removed unused libraries from `src/alita_tools/ocr`
- Added `opencv-python==4.11.0.86` in requirements to support `cv2` library used in `src/alita_tools/ocr/text_detection.py`

### Testing
- Not performed
- [ ] Need to test