### PR TITLE
TestRail: intro update_case; fix get_cases output format

### DIFF
--- a/src/alita_tools/testrail/api_wrapper.py
+++ b/src/alita_tools/testrail/api_wrapper.py
@@ -1,33 +1,39 @@
 import json
 import logging
-from typing import Optional, Any
+from typing import Dict, List, Optional, Union
 
-from testrail_api import TestRailAPI
-from pydantic import model_validator, BaseModel, SecretStr
+import pandas as pd
 from langchain_core.tools import ToolException
-from pydantic import create_model
+from pydantic import SecretStr, create_model, model_validator
 from pydantic.fields import Field, PrivateAttr
-from testrail_api import StatusCodeError
+from testrail_api import StatusCodeError, TestRailAPI
 
 from ..elitea_base import BaseToolApiWrapper
 
 logger = logging.getLogger(__name__)
 
-getCase = create_model(
-    "getCase",
-    testcase_id=(str, Field(description="Testcase id"))
-)
+getCase = create_model("getCase", testcase_id=(str, Field(description="Testcase id")))
 
 getCases = create_model(
     "getCases",
-    project_id=(str, Field(description="Project id"))
+    project_id=(str, Field(description="Project id")),
+    output_format=(
+        str,
+        Field(
+            default="json",
+            description="Desired output format. Supported values: 'json', 'csv', 'markdown'. Defaults to 'json'.",
+        ),
+    ),
 )
 
 getCasesByFilter = create_model(
     "getCasesByFilter",
     project_id=(str, Field(description="Project id")),
-    json_case_arguments=(str, Field(description="""
-        JSON of the test case arguments used to filter test cases.
+    json_case_arguments=(
+        Union[str, dict],
+        Field(
+            description="""
+        JSON (as a string or dictionary) of the test case arguments used to filter test cases.
 
         Supported args:
         :key suite_id: int
@@ -66,15 +72,25 @@ getCasesByFilter = create_model(
             :key updated_by: List[int] or comma-separated string
                 A comma-separated list of user IDs who updated test cases to filter by.
         """
-                                    ))
+        ),
+    ),
+    output_format=(
+        str,
+        Field(
+            default="json",
+            description="Desired output format. Supported values: 'json', 'csv', 'markdown'. Defaults to 'json'.",
+        ),
+    ),
 )
 
 addCase = create_model(
     "addCase",
     section_id=(str, Field(description="Section id")),
     title=(str, Field(description="Title")),
-    case_properties=(Optional[dict], Field(
-        description="""
+    case_properties=(
+        Optional[dict],
+        Field(
+            description="""
         Properties of new test case in a key-value format: testcase_field_name=testcase_field_value.
         Possible arguments
             :key template_id: int
@@ -149,7 +165,99 @@ addCase = create_model(
              - If `shared_step_id` is included, it is preserved for that step.
         - `expected` values must always be strings and are required when `steps` is a single string or may be supplied per step when `steps` is a list.
         """,
-        default={}))
+            default={},
+        ),
+    ),
+)
+
+updateCase = create_model(
+    "updateCase",
+    case_id=(str, Field(description="Case ID")),
+    case_properties=(
+        Optional[dict],
+        Field(
+            description="""
+        Properties of new test case in a key-value format: testcase_field_name=testcase_field_value.
+        Possible arguments
+            :key title: str
+                    The title of the test case
+            :key section_id: int
+                The ID of the section (requires TestRail 6.5.2 or later)
+            :key template_id: int
+                The ID of the template (field layout)
+            :key type_id: int
+                The ID of the case type
+            :key priority_id: int
+                The ID of the case priority
+            :key estimate: str
+                The estimate, e.g. "30s" or "1m 45s"
+            :key milestone_id: int
+                The ID of the milestone to link to the test case
+            :key refs: str
+                A comma-separated list of references/requirements
+
+        Custom fields are supported as well and must be submitted with their
+        system name, prefixed with 'custom_', e.g.:
+        {
+            ...
+            "template_id": 1,
+            "custom_preconds": "These are the preconditions for a test case",
+            "custom_steps": "Step-by-step instructions for the test.",
+            "custom_expected": "The final expected result."
+            ...
+        }
+        OR
+        {
+            ...
+            "template_id": 2,
+            "custom_preconds": "These are the preconditions for a test case",
+            "custom_steps_separated": [
+                {"content": "Step 1 description", "expected": "Step 1 expected result"},
+                {"content": "Step 2 description", "expected": "Step 2 expected result"},
+                {"shared_step_id": 5}
+            ]
+            ...
+        }
+
+        The following custom field types are supported:
+            Checkbox: bool
+                True for checked and false otherwise
+            Date: str
+                A date in the same format as configured for TestRail and API user
+                (e.g. "07/08/2013")
+            Dropdown: int
+                The ID of a dropdown value as configured in the field configuration
+            Integer: int
+                A valid integer
+            Milestone: int
+                The ID of a milestone for the custom field
+            Multi-select: list
+                An array of IDs as configured in the field configuration
+            Steps: list
+                An array of objects specifying the steps. Also see the example below.
+            String: str
+                A valid string with a maximum length of 250 characters
+            Text: str
+                A string without a maximum length
+            URL: str
+                A string with matches the syntax of a URL
+            User: int
+                The ID of a user for the custom field
+
+        **Notes for `steps` and `expected`:**
+        - The `steps` field can take one of two forms based on template id:
+          1. A **string** for simple test steps, mapped to `custom_steps`.
+             - Template ID should be 1 passed as default
+             - The `expected` field in this case should also be a **string** and is mapped to `custom_expected`.
+          2. A **list of dictionaries** for detailed step-by-step instructions, mapped to `custom_steps_separated`.
+             - Template ID should be 2 passed as default
+             - Each dictionary requires a `content` key for the step text and an `expected` key for the individual expected outcome.
+             - If `shared_step_id` is included, it is preserved for that step.
+        - `expected` values must always be strings and are required when `steps` is a single string or may be supplied per step when `steps` is a list.
+        """,
+            default={},
+        ),
+    ),
 )
 
 
@@ -157,9 +265,9 @@ class TestrailAPIWrapper(BaseToolApiWrapper):
     url: str
     password: Optional[SecretStr] = None,
     email: Optional[str] = None,
-    _client: Optional[TestRailAPI] = PrivateAttr()  # Private attribute for the Rally client
+    _client: Optional[TestRailAPI] = PrivateAttr() # Private attribute for the TestRail client
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def validate_toolkit(cls, values):
         try:
@@ -170,72 +278,182 @@ class TestrailAPIWrapper(BaseToolApiWrapper):
                 "`pip install testrail_api`"
             )
 
-        url = values['url']
-        password = values.get('password')
-        email = values.get('email')
+        url = values["url"]
+        password = values.get("password")
+        email = values.get("email")
         cls._client = TestRailAPI(url, email, password)
         return values
 
     def add_case(self, section_id: str, title: str, case_properties: Optional[dict]):
-        """ Adds new test case into Testrail per defined parameters.
-                Parameters:
-                    section_id: str - test case section id.
-                    title: str - new test case title.
-                    case_properties: dict[str, str] - properties of new test case, for examples:
-                        :key template_id: int
-                        The ID of the template
-                        :key type_id: int
-                        The ID of the case type
-                        :key priority_id: int
-                        The ID of the case priority
-                        :key estimate: str
-                        The estimate, e.g. "30s" or "1m 45s"
-                        etc.
-                        Custom fields are supported with prefix 'custom_', e.g.:
-                        :custom_steps: str
-                        Steps in String format (requires template_id: 1)
-                        :custom_steps_separated: dict
-                        Steps in Dict format (requires template_id: 2)
-                        :custom_preconds: str
-                        These are the preconditions for a test case
-            """
+        """Adds new test case into Testrail per defined parameters.
+        Parameters:
+            section_id: str - test case section id.
+            title: str - new test case title.
+            case_properties: dict[str, str] - properties of new test case, for examples:
+                :key template_id: int
+                The ID of the template
+                :key type_id: int
+                The ID of the case type
+                :key priority_id: int
+                The ID of the case priority
+                :key estimate: str
+                The estimate, e.g. "30s" or "1m 45s"
+                etc.
+                Custom fields are supported with prefix 'custom_', e.g.:
+                :custom_steps: str
+                Steps in String format (requires template_id: 1)
+                :custom_steps_separated: dict
+                Steps in Dict format (requires template_id: 2)
+                :custom_preconds: str
+                These are the preconditions for a test case
+        """
         try:
-            created_case = self._client.cases.add_case(section_id=section_id, title=title, **case_properties)
+            created_case = self._client.cases.add_case(
+                section_id=section_id, title=title, **case_properties
+            )
         except StatusCodeError as e:
-            return f"Unable to add new testcase {e}"
+            raise f"Unable to add new testcase {e}"
         return f"New test case has been created: id - {created_case['id']} at '{created_case['created_on']}')"
 
     def get_case(self, testcase_id: str):
-        """ Extracts information about single test case from Testrail"""
+        """Extracts information about single test case from Testrail"""
         try:
             extracted_case = self._client.cases.get_case(testcase_id)
         except StatusCodeError as e:
-            return ToolException(f"Unable to extract testcase {e}")
+            raise ToolException(f"Unable to extract testcase {e}")
         return f"Extracted test case:\n{str(extracted_case)}"
 
-    def get_cases(self, project_id: str):
-        """ Extracts list of test cases in format `case_id - title` from specified project"""
+    def get_cases(
+        self, project_id: str, output_format: str = "json"
+    ) -> Union[str, ToolException]:
+        """
+        Extracts a list of test cases in the specified format: `json`, `csv`, or `markdown`.
+
+        Args:
+            project_id (str): The project ID to extract test cases from.
+            output_format (str): Desired output format. Options are 'json', 'csv', 'markdown'.
+                                Default is 'json'.
+
+        Returns:
+            str: A representation of the test cases in the specified format
+        """
         try:
             extracted_cases = self._client.cases.get_cases(project_id=project_id)
             extracted_cases_data = []
-            for case in extracted_cases['cases']:
-                extracted_cases_data.append({"id": case['id'], "title": case['title']})
+            for case in extracted_cases["cases"]:
+                extracted_cases_data.append({"title": case["title"], "id": case["id"]})
         except StatusCodeError as e:
-            return ToolException(f"Unable to extract testcases {e}")
-        return f"Extracted test case:\n{str(extracted_cases_data)}"
+            raise ToolException(f"Unable to extract testcases {e}")
 
-    def get_cases_by_filter(self, project_id: str, json_case_arguments):
-        """Extracts test cases from specified project and per given case attributes provided as json"""
+        return self._to_markup(extracted_cases_data, output_format)
+
+    def get_cases_by_filter(
+        self,
+        project_id: str,
+        json_case_arguments: Union[str, dict],
+        output_format: str = "json",
+    ) -> Union[str, ToolException]:
+        """
+        Extracts test cases from a specified project based on given case attributes.
+
+        Args:
+            project_id (str): The project ID to extract test cases from.
+            json_case_arguments (Union[str, dict]): The filter attributes for case extraction.
+                                                    Can be a JSON string or a dictionary.
+            output_format (str): Desired output format. Options are 'json', 'csv', 'markdown'.
+                                 Default is 'json'.
+
+        Returns:
+            str: A representation of the test cases in the specified format.
+        """
         try:
-            params = json.loads(json_case_arguments)
-            extracted_cases = self._client.cases.get_cases(project_id=project_id, **params)
+            if isinstance(json_case_arguments, str):
+                params = json.loads(json_case_arguments)
+            elif isinstance(json_case_arguments, dict):
+                params = json_case_arguments
+            else:
+                raise ToolException(
+                    "json_case_arguments must be a JSON string or dictionary."
+                )
+
+            extracted_cases = self._client.cases.get_cases(
+                project_id=project_id, **params
+            )
+
             extracted_cases_data = []
-            if extracted_cases['cases'] is not None:
-                for case in extracted_cases['cases']:
-                    extracted_cases_data.append({"id": case['id'], "title": case['title']})
+            if extracted_cases.get("cases"):
+                extracted_cases_data = [
+                    {"title": case["title"], "id": case["id"]}
+                    for case in extracted_cases["cases"]
+                ]
         except StatusCodeError as e:
-            return ToolException(f"Unable to extract testcases {e}")
-        return f"Extracted test case:\n{str(extracted_cases_data)}"
+            raise ToolException(f"Unable to extract test cases: {e}")
+        except (ValueError, json.JSONDecodeError) as e:
+            raise ToolException(f"Invalid parameter for json_case_arguments: {e}")
+
+        return self._to_markup(extracted_cases_data, output_format)
+
+    def update_case(self, case_id: str, case_properties: Optional[dict]):
+        """Updates an existing test case (partial updates are supported, i.e.
+        you can submit and update specific fields only).
+
+        :param case_id: T
+            he ID of the test case
+        :param kwargs:
+            :key title: str
+                The title of the test case
+            :key section_id: int
+                The ID of the section (requires TestRail 6.5.2 or later)
+            :key template_id: int
+                The ID of the template (requires TestRail 5.2 or later)
+            :key type_id: int
+                The ID of the case type
+            :key priority_id: int
+                The ID of the case priority
+            :key estimate: str
+                The estimate, e.g. "30s" or "1m 45s"
+            :key milestone_id: int
+                The ID of the milestone to link to the test case
+            :key refs: str
+                A comma-separated list of references/requirements
+        :return: response
+        """
+        try:
+            updated_case = self._client.cases.update_case(
+                case_id=case_id, **case_properties
+            )
+        except StatusCodeError as e:
+            raise f"Unable to update testcase #{case_id} due to {e}"
+        return (
+            f"Test case #{case_id} has been updated at '{updated_case['updated_on']}')"
+        )
+
+    def _to_markup(self, data: List[Dict], output_format: str) -> str:
+        """
+        Converts the given data into the specified format: 'json', 'csv', or 'markdown'.
+
+        Args:
+            data (List[Dict]): The data to convert.
+            output_format (str): Desired output format.
+
+        Returns:
+            str: The data in the specified format.
+        """
+        if output_format not in {"json", "csv", "markdown"}:
+            raise ToolException(
+                f"Invalid format `{output_format}`. Supported formats: 'json', 'csv', 'markdown'."
+            )
+
+        if output_format == "json":
+            return f"Extracted test cases:\n{data}"
+
+        df = pd.DataFrame(data)
+
+        if output_format == "csv":
+            return df.to_csv(index=False)
+
+        if output_format == "markdown":
+            return df.to_markdown(index=False)
 
     def get_available_tools(self):
         return [
@@ -262,5 +480,11 @@ class TestrailAPIWrapper(BaseToolApiWrapper):
                 "ref": self.add_case,
                 "description": self.add_case.__doc__,
                 "args_schema": addCase,
-            }
+            },
+            {
+                "name": "update_case",
+                "ref": self.update_case,
+                "description": self.update_case.__doc__,
+                "args_schema": updateCase,
+            },
         ]


### PR DESCRIPTION
### Changes
1. Introduced `update_case` method for TestRail
2. Fix output format for `get_cases` and `get_cases_by_filter`: now it is possible to pass parameter `output_format` (json, csv, markdown)
3. Code refactoring

### Local testing
Tested successfully on DEV env

- <img width="750" alt="get_cases_format_md" src="https://github.com/user-attachments/assets/11c17864-160e-4a47-a854-91d49fd2a6ac" />
- <img width="750" alt="get_cases_format_csv" src="https://github.com/user-attachments/assets/6e50162c-4d9e-4499-8b69-fd8cf732950b" />
- <img width="750" alt="get_cases_format_json" src="https://github.com/user-attachments/assets/48b4f996-db0f-44b9-9ea1-f461ec03512f" />
- <img width="750" alt="update_case_result" src="https://github.com/user-attachments/assets/9b00eeb9-b462-49cc-8b1e-9660fa1bc379" />
