### PR TITLE
Zephyr Scale enhancements - search cases capability

### DIFF
--- a/src/alita_tools/zephyr_scale/api_wrapper.py
+++ b/src/alita_tools/zephyr_scale/api_wrapper.py
@@ -151,6 +151,70 @@ ZephyrCreateTestScript = create_model(
     text=(str, Field(description="The text content of the script"))
 )
 
+ZephyrSearchTestCases = create_model(
+    "ZephyrSearchTestCases",
+    project_id=(str, Field(description="Jira project key filter")),
+    search_term=(Optional[str], Field(description="Optional search term to filter test cases", default=None)),
+    max_results=(Optional[int], Field(description="Maximum number of results to query from the API", default=1000)),
+    start_at=(Optional[int], Field(description="Zero-indexed starting position", default=0)),
+    order_by=(Optional[str], Field(description="Field to order results by", default="name")),
+    order_direction=(Optional[str], Field(description="Order direction", default="ASC")),
+    archived=(Optional[bool], Field(description="Include archived test cases", default=False)),
+    fields=(Optional[List[str]], Field(description="Fields to include in the response (default: key, name)", default=["key", "name"])),
+    limit_results=(Optional[int], Field(description="Maximum number of filtered results to return", default=10)),
+    folder_id=(Optional[str], Field(description="Filter test cases by folder ID", default=None)),
+    folder_name=(Optional[str], Field(description="Filter test cases by folder name (full or partial)", default=None)),
+    exact_folder_match=(Optional[bool], Field(description="Whether to match the folder name exactly or allow partial matches", default=False)),
+    folder_path=(Optional[str], Field(description="Filter test cases by folder path (e.g., 'Root/Parent/Child')", default=None)),
+    include_subfolders=(Optional[bool], Field(description="Include test cases from subfolders of matching folders", default=True)),
+    labels=(Optional[List[str]], Field(description="Filter test cases by labels", default=None))
+)
+
+ZephyrGetTestsRecursive = create_model(
+    "ZephyrGetTestsRecursive",
+    project_key=(Optional[str], Field(description="Jira project key filter", default=None)),
+    folder_id=(Optional[str], Field(description="Parent folder ID to start the recursive search from", default=None)),
+    maxResults=(Optional[int], Field(
+        description="A hint as to the maximum number of results to return in each call. Must be an integer >= 1.", 
+        default=100)),
+    startAt=(Optional[int], Field(
+        description="Zero-indexed starting position. Should be a multiple of maxResults.",
+        default=0))
+)
+
+ZephyrGetTestsByFolderName = create_model(
+    "ZephyrGetTestsByFolderName",
+    project_key=(str, Field(description="Jira project key filter")),
+    folder_name=(str, Field(description="Full or partial folder name to search for")),
+    exact_match=(Optional[bool], Field(
+        description="Whether to match the folder name exactly or allow partial matches",
+        default=False)),
+    include_subfolders=(Optional[bool], Field(
+        description="Whether to include test cases from subfolders",
+        default=True)),
+    maxResults=(Optional[int], Field(
+        description="A hint as to the maximum number of results to return in each call. Must be an integer >= 1.",
+        default=100)),
+    startAt=(Optional[int], Field(
+        description="Zero-indexed starting position. Should be a multiple of maxResults.",
+        default=0))
+)
+
+ZephyrGetTestsByFolderPath = create_model(
+    "ZephyrGetTestsByFolderPath",
+    project_key=(str, Field(description="Jira project key filter")),
+    folder_path=(str, Field(description="Full folder path (e.g., 'Root/Parent/Child')")),
+    include_subfolders=(Optional[bool], Field(
+        description="Whether to include test cases from subfolders",
+        default=True)),
+    maxResults=(Optional[int], Field(
+        description="A hint as to the maximum number of results to return in each call. Must be an integer >= 1.",
+        default=100)),
+    startAt=(Optional[int], Field(
+        description="Zero-indexed starting position. Should be a multiple of maxResults.",
+        default=0))
+)
+
 
 class ZephyrScaleApiWrapper(BaseToolApiWrapper):
     # url for a Zephyr server
@@ -434,6 +498,334 @@ class ZephyrScaleApiWrapper(BaseToolApiWrapper):
             return f"Test script created/updated for test case `{test_case_key}`: {str(script_response)}"
         except Exception as e:
             return ToolException(f"Unable to create/update test script for test case with key: {test_case_key}:\n{str(e)}")
+            
+    def search_test_cases(self, project_id: str, search_term: Optional[str] = None, 
+                         max_results: Optional[int] = 1000, start_at: Optional[int] = 0,
+                         order_by: Optional[str] = "name", order_direction: Optional[str] = "ASC", 
+                         archived: Optional[bool] = False, fields: Optional[List[str]] = ["key", "name"],
+                         limit_results: Optional[int] = None, folder_id: Optional[str] = None,
+                         folder_name: Optional[str] = None, exact_folder_match: Optional[bool] = False,
+                         folder_path: Optional[str] = None, include_subfolders: Optional[bool] = True,
+                         labels: Optional[List[str]] = None) -> str:
+        """Searches for test cases using custom search API.
+        
+        Args:
+            project_id: Jira project key (e.g., "SIT", "PROJ")
+            search_term: Optional search term to filter test cases
+            max_results: Maximum number of results to query from the API
+            start_at: Zero-indexed starting position
+            order_by: Field to order results by
+            order_direction: Order direction (ASC or DESC)
+            archived: Include archived test cases
+            fields: Fields to include in the response (default: key, name)
+            limit_results: Maximum number of filtered results to return
+            folder_id: Filter test cases by folder ID
+            folder_name: Filter test cases by folder name (full or partial)
+            exact_folder_match: Whether to match the folder name exactly or allow partial matches
+            folder_path: Filter test cases by folder path (e.g., 'Root/Parent/Child')
+            include_subfolders: Include test cases from subfolders of matching folders
+            labels: Filter test cases by labels
+        """
+        try:
+            # Use the Python SDK for searching test cases
+            logger.debug("Searching test cases using the Python SDK")
+            
+            # First, handle folder name and folder path search
+            target_folder_ids = []
+            
+            # If we have folder_name or folder_path, we need to build the folder hierarchy
+            if folder_name or folder_path:
+                # Get all folders in the project
+                all_folders = []
+                try:
+                    for folder in self._api.folders.get_folders(
+                        maxResults=max_results, 
+                        projectKey=project_id, 
+                        folderType="TEST_CASE"
+                    ):
+                        all_folders.append(folder)
+                except Exception as e:
+                    return ToolException(f"Error getting folders: {str(e)}")
+                
+                # Build folder hierarchy
+                folder_hierarchy = {}
+                for folder in all_folders:
+                    folder_id_val = folder.get('id')
+                    parent_id = folder.get('parentId')
+                    if folder_id_val not in folder_hierarchy:
+                        folder_hierarchy[folder_id_val] = {
+                            'folder': folder,
+                            'children': []
+                        }
+                    else:
+                        folder_hierarchy[folder_id_val]['folder'] = folder
+                    
+                    if parent_id:
+                        if parent_id not in folder_hierarchy:
+                            folder_hierarchy[parent_id] = {
+                                'folder': None,
+                                'children': [folder_id_val]
+                            }
+                        else:
+                            folder_hierarchy[parent_id]['children'].append(folder_id_val)
+                
+                # Handle folder name search
+                if folder_name:
+                    # Find folders matching the name
+                    for folder in all_folders:
+                        folder_name_val = folder.get('name', '')
+                        if exact_folder_match:
+                            if folder_name_val == folder_name:
+                                target_folder_ids.append(folder.get('id'))
+                        else:
+                            if folder_name.lower() in folder_name_val.lower():
+                                target_folder_ids.append(folder.get('id'))
+                
+                # Handle folder path search
+                if folder_path:
+                    folder_paths = {}
+                    root_folders = []
+                    
+                    # Identify root folders
+                    for folder in all_folders:
+                        if not folder.get('parentId'):
+                            root_folders.append(folder.get('id'))
+                    
+                    # Function to build full paths for each folder
+                    def build_folder_paths(folder_id, current_path=""):
+                        if folder_id not in folder_hierarchy or not folder_hierarchy[folder_id]['folder']:
+                            return
+                        
+                        folder_name = folder_hierarchy[folder_id]['folder'].get('name', '')
+                        if current_path:
+                            full_path = f"{current_path}/{folder_name}"
+                        else:
+                            full_path = folder_name
+                        
+                        folder_paths[folder_id] = full_path
+                        
+                        # Process children
+                        for child_id in folder_hierarchy[folder_id]['children']:
+                            build_folder_paths(child_id, full_path)
+                    
+                    # Build paths starting from root folders
+                    for root_id in root_folders:
+                        build_folder_paths(root_id)
+                    
+                    # Find the folder matching the exact path
+                    for folder_id, path in folder_paths.items():
+                        if path == folder_path:
+                            target_folder_ids.append(folder_id)
+                            break
+                
+                # If include_subfolders is True, add all subfolders of matching folders
+                if include_subfolders and target_folder_ids:
+                    # Function to recursively collect subfolders
+                    def collect_subfolders(parent_folder_id, collected_folders=None):
+                        if collected_folders is None:
+                            collected_folders = set()
+                        
+                        if parent_folder_id not in folder_hierarchy or parent_folder_id in collected_folders:
+                            return
+                        
+                        collected_folders.add(parent_folder_id)
+                        
+                        for child_id in folder_hierarchy[parent_folder_id].get('children', []):
+                            if child_id not in collected_folders:
+                                target_folder_ids.append(child_id)
+                                collect_subfolders(child_id, collected_folders)
+                    
+                    # Start recursive collection for each matching folder
+                    original_target_ids = target_folder_ids.copy()
+                    for folder_id in original_target_ids:
+                        collect_subfolders(folder_id)
+                
+                # Remove duplicates from target folder IDs
+                target_folder_ids = list(set(target_folder_ids))
+                
+                # If we have target folder IDs but no folder_id is specified, use the first one
+                if target_folder_ids and not folder_id:
+                    folder_id = target_folder_ids[0]
+            
+            # Prepare parameters for the SDK call
+            params = {
+                "projectKey": project_id,
+                "maxResults": max_results,
+                "startAt": start_at
+            }
+            
+            # Add folder_id if provided or found through folder name/path search
+            if folder_id:
+                params["folderId"] = folder_id
+            
+            # Get test cases from the API
+            all_test_cases = []
+            
+            # If we have multiple target folder IDs, get test cases from each folder
+            if target_folder_ids and include_subfolders:
+                for target_id in target_folder_ids:
+                    folder_params = params.copy()
+                    folder_params["folderId"] = target_id
+                    try:
+                        test_cases = self._api.test_cases.get_test_cases(**folder_params)
+                        all_test_cases.extend(test_cases)
+                    except Exception as e:
+                        logger.warning(f"Error getting test cases from folder {target_id}: {str(e)}")
+            else:
+                # Just use the standard params (which might include a single folder_id)
+                all_test_cases = self._api.test_cases.get_test_cases(**params)
+            
+            # Apply filtering based on search term and labels
+            filtered_cases = []
+            for tc in all_test_cases:
+                # Apply search term filter if provided
+                search_match = True
+                if search_term:
+                    search_match = (search_term.lower() in tc.get('name', '').lower() or 
+                                    search_term.lower() in tc.get('key', '').lower())
+                
+                # Apply labels filter if provided
+                labels_match = True
+                if labels and len(labels) > 0:
+                    tc_labels = tc.get('labels', [])
+                    # Check if at least one of the specified labels exists in the test case
+                    labels_match = any(label in tc_labels for label in labels)
+                
+                # Add test case if it matches all filters
+                if search_match and labels_match:
+                    filtered_cases.append(tc)
+            
+            # Sort the results if needed
+            if order_by and filtered_cases:
+                reverse = order_direction.upper() == "DESC"
+                filtered_cases.sort(key=lambda x: x.get(order_by, ''), reverse=reverse)
+            
+            # Limit the number of results if specified
+            if limit_results is not None and limit_results < len(filtered_cases):
+                filtered_cases = filtered_cases[:limit_results]
+            
+            # Keep only the requested fields for each test case
+            result_cases = []
+            for tc in filtered_cases:
+                result_case = {}
+                for field in fields:
+                    if field in tc:
+                        result_case[field] = tc[field]
+                result_cases.append(result_case)
+            
+            # Build a helpful response message
+            response_details = []
+            if folder_name:
+                response_details.append(f"folder name '{folder_name}'")
+            if folder_path:
+                response_details.append(f"folder path '{folder_path}'")
+            if folder_id:
+                response_details.append(f"folder ID '{folder_id}'")
+            if search_term:
+                response_details.append(f"search term '{search_term}'")
+            if labels:
+                response_details.append(f"labels {labels}")
+            
+            search_details = " and ".join(response_details)
+            message = f"Found {len(result_cases)} test cases"
+            if search_details:
+                message += f" matching {search_details}"
+            
+            return f"{message}: {json.dumps(result_cases, indent=2)}"
+                
+        except Exception as e:
+            return ToolException(f"Error searching test cases: {str(e)}")
+
+    def get_tests_recursive(self, project_key: str = None, folder_id: str = None, maxResults: Optional[int] = 100, startAt: Optional[int] = 0):
+        """Retrieves all test cases recursively from a folder and all its subfolders.
+        
+        Args:
+            project_key: Jira project key filter
+            folder_id: Parent folder ID to start the recursive search from
+            maxResults: A hint as to the maximum number of results to return in each call
+            startAt: Zero-indexed starting position. Should be a multiple of maxResults
+            
+        Returns:
+            A string with all test cases found in the folder and its subfolders
+        """
+        # Store all test cases
+        all_test_cases = []
+        
+        # First, get all test cases from the specified folder
+        kwargs = {}
+        if project_key:
+            kwargs["projectKey"] = project_key
+        if folder_id:
+            kwargs["folderId"] = folder_id
+        kwargs["maxResults"] = maxResults
+        kwargs["startAt"] = startAt
+        
+        # Get test cases from the specified folder
+        try:
+            test_cases = self._api.test_cases.get_test_cases(**kwargs)
+            all_test_cases.extend(test_cases)
+        except Exception as e:
+            return ToolException(f"Error getting test cases from folder {folder_id}: {str(e)}")
+        
+        # Get all folders in the project
+        all_folders = []
+        try:
+            for folder in self._api.folders.get_folders(
+                maxResults=100, 
+                projectKey=project_key, 
+                folderType="TEST_CASE"
+            ):
+                all_folders.append(folder)
+        except Exception as e:
+            return ToolException(f"Error getting folders: {str(e)}")
+        
+        # Build folder hierarchy
+        folder_hierarchy = {}
+        for folder in all_folders:
+            folder_id_val = folder.get('id')
+            parent_id = folder.get('parentId')
+            if folder_id_val not in folder_hierarchy:
+                folder_hierarchy[folder_id_val] = {
+                    'folder': folder,
+                    'children': []
+                }
+            else:
+                folder_hierarchy[folder_id_val]['folder'] = folder
+                
+            if parent_id:
+                if parent_id not in folder_hierarchy:
+                    folder_hierarchy[parent_id] = {
+                        'folder': None,
+                        'children': [folder_id_val]
+                    }
+                else:
+                    folder_hierarchy[parent_id]['children'].append(folder_id_val)
+        
+        # Function to recursively collect test cases from subfolders
+        def collect_subfolder_tests(parent_folder_id):
+            if parent_folder_id not in folder_hierarchy:
+                return
+            
+            for child_id in folder_hierarchy[parent_folder_id]['children']:
+                # Get test cases from this subfolder
+                subfolder_kwargs = kwargs.copy()
+                subfolder_kwargs["folderId"] = child_id
+                try:
+                    subfolder_test_cases = self._api.test_cases.get_test_cases(**subfolder_kwargs)
+                    all_test_cases.extend(subfolder_test_cases)
+                except Exception as e:
+                    logger.warning(f"Error getting test cases from subfolder {child_id}: {str(e)}")
+                
+                # Recursively process this subfolder's children
+                collect_subfolder_tests(child_id)
+        
+        # Start recursive collection if a folder ID was specified
+        if folder_id:
+            collect_subfolder_tests(folder_id)
+        
+        # Convert the test cases to a string
+        parsed_tests = self._parse_tests(all_test_cases)
+        return f"Extracted {len(all_test_cases)} tests recursively: {str(parsed_tests)}"
 
     @staticmethod
     def _parse_tests(tests) -> list:
@@ -477,6 +869,256 @@ class ZephyrScaleApiWrapper(BaseToolApiWrapper):
                 test_item.append("Owner Account ID: None")
             parsed_tests.append(test_item)
         return parsed_tests
+    
+    def get_tests_by_folder_name(self, project_key: str, folder_name: str, exact_match: Optional[bool] = False, 
+                             include_subfolders: Optional[bool] = True, maxResults: Optional[int] = 100, 
+                             startAt: Optional[int] = 0):
+        """Retrieves all test cases from folders matching the specified name.
+        
+        Args:
+            project_key: Jira project key filter
+            folder_name: Full or partial folder name to search for
+            exact_match: Whether to match the folder name exactly or allow partial matches
+            include_subfolders: Whether to include test cases from subfolders of matching folders
+            maxResults: A hint as to the maximum number of results to return in each call
+            startAt: Zero-indexed starting position. Should be a multiple of maxResults
+            
+        Returns:
+            A string with all test cases found in matching folders
+        """
+        # Store all test cases and matching folder IDs
+        all_test_cases = []
+        matching_folder_ids = []
+        
+        # Get all folders in the project
+        all_folders = []
+        try:
+            for folder in self._api.folders.get_folders(
+                maxResults=100, 
+                projectKey=project_key, 
+                folderType="TEST_CASE"
+            ):
+                all_folders.append(folder)
+        except Exception as e:
+            return ToolException(f"Error getting folders: {str(e)}")
+        
+        # Find folders matching the name
+        for folder in all_folders:
+            folder_name_val = folder.get('name', '')
+            if exact_match:
+                if folder_name_val == folder_name:
+                    matching_folder_ids.append(folder.get('id'))
+            else:
+                if folder_name.lower() in folder_name_val.lower():
+                    matching_folder_ids.append(folder.get('id'))
+        
+        if not matching_folder_ids:
+            return f"No folders found matching name: {folder_name}"
+            
+        # Build folder hierarchy if we need to include subfolders
+        folder_hierarchy = {}
+        if include_subfolders:
+            for folder in all_folders:
+                folder_id_val = folder.get('id')
+                parent_id = folder.get('parentId')
+                if folder_id_val not in folder_hierarchy:
+                    folder_hierarchy[folder_id_val] = {
+                        'folder': folder,
+                        'children': []
+                    }
+                else:
+                    folder_hierarchy[folder_id_val]['folder'] = folder
+                
+                if parent_id:
+                    if parent_id not in folder_hierarchy:
+                        folder_hierarchy[parent_id] = {
+                            'folder': None,
+                            'children': [folder_id_val]
+                        }
+                    else:
+                        folder_hierarchy[parent_id]['children'].append(folder_id_val)
+        
+        # Function to recursively collect test cases from subfolders
+        def collect_subfolder_tests(parent_folder_id, collected_folders=None):
+            if collected_folders is None:
+                collected_folders = set()
+                
+            if parent_folder_id not in folder_hierarchy or parent_folder_id in collected_folders:
+                return
+                
+            collected_folders.add(parent_folder_id)
+            
+            for child_id in folder_hierarchy[parent_folder_id].get('children', []):
+                if child_id not in collected_folders:
+                    # Add this subfolder ID to our list of folders to search
+                    matching_folder_ids.append(child_id)
+                    # Recursively process this subfolder's children
+                    collect_subfolder_tests(child_id, collected_folders)
+        
+        # Start recursive collection for each matching folder if including subfolders
+        if include_subfolders:
+            original_matching_ids = matching_folder_ids.copy()
+            for folder_id in original_matching_ids:
+                collect_subfolder_tests(folder_id)
+        
+        # Remove duplicates from matching folder IDs
+        matching_folder_ids = list(set(matching_folder_ids))
+        
+        # Get test cases from all matching folders
+        for folder_id in matching_folder_ids:
+            try:
+                folder_test_cases = self._api.test_cases.get_test_cases(
+                    projectKey=project_key,
+                    folderId=folder_id,
+                    maxResults=maxResults,
+                    startAt=startAt
+                )
+                all_test_cases.extend(folder_test_cases)
+            except Exception as e:
+                logger.warning(f"Error getting test cases from folder {folder_id}: {str(e)}")
+        
+        # Convert the test cases to a string
+        parsed_tests = self._parse_tests(all_test_cases)
+        return f"Extracted {len(all_test_cases)} tests from {len(matching_folder_ids)} folders matching '{folder_name}': {str(parsed_tests)}"
+
+    def get_tests_by_folder_path(self, project_key: str, folder_path: str, include_subfolders: Optional[bool] = True,
+                                maxResults: Optional[int] = 100, startAt: Optional[int] = 0):
+        """Retrieves all test cases from a folder specified by its path.
+        
+        Args:
+            project_key: Jira project key filter
+            folder_path: Full folder path (e.g., 'Root/Parent/Child')
+            include_subfolders: Whether to include test cases from subfolders
+            maxResults: A hint as to the maximum number of results to return in each call
+            startAt: Zero-indexed starting position. Should be a multiple of maxResults
+            
+        Returns:
+            A string with all test cases found in the specified folder path
+        """
+        # Store all test cases
+        all_test_cases = []
+        
+        # Get all folders in the project
+        all_folders = []
+        try:
+            for folder in self._api.folders.get_folders(
+                maxResults=100, 
+                projectKey=project_key, 
+                folderType="TEST_CASE"
+            ):
+                all_folders.append(folder)
+        except Exception as e:
+            return ToolException(f"Error getting folders: {str(e)}")
+        
+        # Build folder hierarchy with paths
+        folder_hierarchy = {}
+        folder_paths = {}
+        root_folders = []
+        
+        # First pass: collect all folders and their basic relationships
+        for folder in all_folders:
+            folder_id = folder.get('id')
+            parent_id = folder.get('parentId')
+            
+            if folder_id not in folder_hierarchy:
+                folder_hierarchy[folder_id] = {
+                    'folder': folder,
+                    'children': []
+                }
+            else:
+                folder_hierarchy[folder_id]['folder'] = folder
+                
+            if parent_id:
+                if parent_id not in folder_hierarchy:
+                    folder_hierarchy[parent_id] = {
+                        'folder': None,
+                        'children': [folder_id]
+                    }
+                else:
+                    folder_hierarchy[parent_id]['children'].append(folder_id)
+            else:
+                # This is a root folder
+                root_folders.append(folder_id)
+        
+        # Function to build full paths for each folder
+        def build_folder_paths(folder_id, current_path=""):
+            if folder_id not in folder_hierarchy or not folder_hierarchy[folder_id]['folder']:
+                return
+                
+            folder_name = folder_hierarchy[folder_id]['folder'].get('name', '')
+            if current_path:
+                full_path = f"{current_path}/{folder_name}"
+            else:
+                full_path = folder_name
+                
+            folder_paths[folder_id] = full_path
+            
+            # Process children
+            for child_id in folder_hierarchy[folder_id]['children']:
+                build_folder_paths(child_id, full_path)
+        
+        # Build paths starting from root folders
+        for root_id in root_folders:
+            build_folder_paths(root_id)
+        
+        # Find the folder matching the exact path
+        target_folder_id = None
+        for folder_id, path in folder_paths.items():
+            if path == folder_path:
+                target_folder_id = folder_id
+                break
+        
+        if not target_folder_id:
+            return f"No folder found with path: {folder_path}"
+        
+        # Get test cases from the target folder
+        try:
+            folder_test_cases = self._api.test_cases.get_test_cases(
+                projectKey=project_key,
+                folderId=target_folder_id,
+                maxResults=maxResults,
+                startAt=startAt
+            )
+            all_test_cases.extend(folder_test_cases)
+        except Exception as e:
+            return ToolException(f"Error getting test cases from folder path {folder_path}: {str(e)}")
+        
+        # If including subfolders, recursively get test cases from subfolders
+        if include_subfolders:
+            # Function to recursively collect test cases from subfolders
+            def collect_subfolder_tests(parent_folder_id, collected_folders=None):
+                if collected_folders is None:
+                    collected_folders = set()
+                    
+                if parent_folder_id not in folder_hierarchy or parent_folder_id in collected_folders:
+                    return
+                    
+                collected_folders.add(parent_folder_id)
+                
+                for child_id in folder_hierarchy[parent_folder_id].get('children', []):
+                    if child_id not in collected_folders:
+                        # Get test cases from this subfolder
+                        try:
+                            subfolder_test_cases = self._api.test_cases.get_test_cases(
+                                projectKey=project_key,
+                                folderId=child_id,
+                                maxResults=maxResults,
+                                startAt=startAt
+                            )
+                            all_test_cases.extend(subfolder_test_cases)
+                        except Exception as e:
+                            logger.warning(f"Error getting test cases from subfolder {child_id}: {str(e)}")
+                        
+                        # Recursively process this subfolder's children
+                        collect_subfolder_tests(child_id, collected_folders)
+            
+            # Start recursive collection from the target folder
+            collect_subfolder_tests(target_folder_id)
+        
+        # Convert the test cases to a string
+        parsed_tests = self._parse_tests(all_test_cases)
+        return f"Extracted {len(all_test_cases)} tests from folder path '{folder_path}': {str(parsed_tests)}"
+    
 
     def get_available_tools(self):
         return [
@@ -563,5 +1205,29 @@ class ZephyrScaleApiWrapper(BaseToolApiWrapper):
                 "description": self.create_test_script.__doc__,
                 "args_schema": ZephyrCreateTestScript,
                 "ref": self.create_test_script,
+            },
+            {
+                "name": "search_test_cases",
+                "description": self.search_test_cases.__doc__,
+                "args_schema": ZephyrSearchTestCases,
+                "ref": self.search_test_cases,
+            },
+            {
+                "name": "get_tests_recursive",
+                "description": self.get_tests_recursive.__doc__,
+                "args_schema": ZephyrGetTestsRecursive,
+                "ref": self.get_tests_recursive,
+            },
+            {
+                "name": "get_tests_by_folder_name",
+                "description": self.get_tests_by_folder_name.__doc__,
+                "args_schema": ZephyrGetTestsByFolderName,
+                "ref": self.get_tests_by_folder_name,
+            },
+            {
+                "name": "get_tests_by_folder_path",
+                "description": self.get_tests_by_folder_path.__doc__,
+                "args_schema": ZephyrGetTestsByFolderPath,
+                "ref": self.get_tests_by_folder_path,
             }
         ]


### PR DESCRIPTION
Added several methods to support test cases search in zephyr.

Examples 
`from src.alita_tools.zephyr_scale.api_wrapper import ZephyrScaleApiWrapper

# Initialize Zephyr API wrapper
zephyr = ZephyrScaleApiWrapper(
    token="ZephyrToken",
    max_results=100
)
# get test case
print(zephyr.get_test(test_case_key="PROJ-T12345"))
print(zephyr.get_test_script(test_case_key="PROJ-T12345"))
print(zephyr.get_test_steps(test_case_key="PROJ-T12345"))

NOTE: Search_term doesn't support search in steps, only in title

# Example 1: Basic search filtering by name/key with "Mobile"
print("Example 1: Basic search filtering by name/key with 'Mobile'")
print(zephyr.search_test_cases(
    project_id="PROJ",  # Use project key instead of ID
    search_term="Mobile",
    max_results=1000,  # Maximum results to query from API (multipage query supported)
    fields=["key", "name", "id", "labels", "folder"],  # Include labels and folder in the response
    limit_results=5  # Limit the final results after filtering
))

# Example 2: Filter by "Elitea" label
print("\nExample 2: Filter by 'Elitea' label")
print(zephyr.search_test_cases(
    project_id="PROJ",
    search_term="Mobile",
    max_results=100,
    fields=["key", "name", "id", "labels", "folder"],
    limit_results=5,
    labels=["Elitea"]
))

# Example 3: Filter by specific folder ID
print("\nExample 3: Filter by specific folder ID")
print(zephyr.search_test_cases(
    project_id="PROJ",
    search_term="Mobile",
    max_results=100,
    fields=["key", "name", "id", "labels", "folder"],
    limit_results=5,
    folder_id="1234567"  # Using folder ID 
))

# Example 4: Combined filtering by label and folder
# Uncomment to test with a real folder ID
print("\nExample 4: Combined filtering by label and folder")
print(zephyr.search_test_cases(
    project_id="PROJ",
    search_term="Mobile",
    max_results=100,
    fields=["key", "name", "id", "labels", "folder"],
    limit_results=5,
    labels=["Sitecore"],
    folder_id="1234567"
))

# Example 5: Search with no results
print("\nExample 5: Search with no results")
print(zephyr.search_test_cases(
    project_id="PROJ",
    search_term="NonExistentTestCase",
    max_results=100,
    fields=["key", "name", "id", "labels", "folder"],
    limit_results=5
))
print(zephyr.search_test_cases(
    project_id="PROJ", 
    folder_path="/Web/Regular/global-country/Booking Flow",
    include_subfolders=True,
    max_results=1000,  # Maximum results to query from API
    fields=["key", "name", "id", "labels", "folder"],  # Include labels and folder in the response
))`