### PR TITLE
fix: handle empty method_kwargs param in generic_github_api_call method

### DIFF
--- a/src/alita_tools/github/schemas.py
+++ b/src/alita_tools/github/schemas.py
@@ -174,7 +174,7 @@ GetWorkflowLogs = create_model(
 GenericGithubAPICall = create_model(
     "GenericGithubAPICall",
     method=(str, Field(description="The GitHub API method to call (e.g., 'get_repo', 'get_user')")),
-    method_kwargs=(Dict[str, Any], Field(description="Keyword arguments for the API method as a dictionary"))
+    method_kwargs=(Optional[Dict[str, Any]], Field(description="Keyword arguments for the API method as a dictionary"))
 )
 
 ListProjectIssues = create_model(


### PR DESCRIPTION
### Fix
This is to fix bug: [#1212](https://github.com/ProjectAlita/projectalita.github.io/issues/1212)
**Root cause:** method failed because required params were not passed in prompt

### Testing
Tested locally on DEV env. The two prompts were used (get_repo, get_user):
<img width="700" alt="fix_generic_github_api_call_1" src="https://github.com/user-attachments/assets/f2a4a681-c127-4ce6-bf29-3060537d2991" />
<img width="700" alt="fix_generic_github_api_call_2" src="https://github.com/user-attachments/assets/e838d802-1379-41bb-aaee-bcb0a98b6ef4" />
<img width="700" alt="fix_generic_github_api_call_3" src="https://github.com/user-attachments/assets/069011b8-cf22-4468-b79f-5cc8c71968c8" />
<img width="700" alt="fix_generic_github_api_call_4" src="https://github.com/user-attachments/assets/35798d30-4f6d-4d14-b7e7-ab41b2a48ce7" />